### PR TITLE
[RFC] FEM code overhaul

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -15,7 +15,7 @@ The CoherentStructures.jl package is liscensed under the GPL liscense version 3.
 >You should have received a copy of the GNU General Public License
 >along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-The `nodeToDHTable` and `gridContext{3}(::Type{JuAFEM.QuadraticTetrahedron}...)` are modifications
+The `nodeToDHTable` and `GridContext{3}(::Type{JuAFEM.QuadraticTetrahedron}...)` are modifications
 of functions from the JuAFEM.jl package, these are liscensed under the MIT "Expat" liscense. 
 
 > Copyright (c) 2015-2016: Kristoffer Carlsson.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,38 +16,38 @@ end
 # generate the example notebooks for the documentation
 OUTPUT = joinpath(@__DIR__, "src/generated")
 
-function mypreprocess(content,whatkind)
+function mypreprocess(content, whatkind)
     global cont = content
     while true
         current_location = findfirst("DISPLAY_PLOT",content)
-        if current_location == nothing
+        if current_location === nothing
             break
         end
         @assert content[current_location[end] + 1] == '('
         closing_bracket = findfirst(")",content[current_location[end]:end])
-        @assert closing_bracket != nothing
+        @assert closing_bracket !== nothing
         closing_bracket  = closing_bracket .+ (current_location[end]-1)
 
         args = content[(current_location[end]+2): (closing_bracket[1]-1)]
-        @assert findfirst(",",args) != nothing
+        @assert findfirst(",",args) !== nothing
         figname = args[1:(findfirst(",",args)[1]-1)]
         file_name = args[(findfirst(",",args)[1]+1):end]
 
         @assert length(file_name) > 1
         @assert length(figname) > 1
 
-        if whatkind == :markdown
+        if whatkind === :markdown
             linkloc="https://raw.githubusercontent.com/natschil/misc/master/autogen/" * file_name *".png"
             inner_text = "# ![]($linkloc)"
-        elseif whatkind == :notebook || whatkind == :julia_norun
+        elseif whatkind === :notebook || whatkind == :julia_norun
             inner_text = "Plots.plot($figname)"
-        elseif whatkind == :julia_run
+        elseif whatkind === :julia_run
             inner_text = "Plots.png($figname,\"/tmp/natschil_misc/autogen/$file_name.png\")"
         end
 
         content = content[1:(current_location[1]-1)] * inner_text * content[(closing_bracket[1]+1):end]
     end
-    if whatkind == :julia_run
+    if whatkind === :julia_run
         content = replace(content,"addprocs()" => "addprocs(exeflags=\"--project=docs/\")")
         content = replace(content, "OCEAN_FLOW_FILE" => "\"examples/Ocean_geostrophic_velocity.jld2\"")
     else
@@ -56,80 +56,65 @@ function mypreprocess(content,whatkind)
     return content
 end
 
-preprocess_markdown = x->mypreprocess(x,:markdown)
-preprocess_notebook = x->mypreprocess(x,:notebook)
-preprocess_script = x->mypreprocess(x,:julia_norun)
-preprocess_script2 = x->mypreprocess(x,:julia_run)
+preprocess_markdown = x -> mypreprocess(x, :markdown)
+preprocess_notebook = x -> mypreprocess(x, :notebook)
+preprocess_script = x -> mypreprocess(x, :julia_norun)
+preprocess_script2 = x -> mypreprocess(x, :julia_run)
 
 Literate.markdown(joinpath(@__DIR__, "..", "examples/bickley.jl"), OUTPUT;
-    documenter=false,preprocess=preprocess_markdown)
+    documenter=false, preprocess=preprocess_markdown)
 Literate.notebook(joinpath(@__DIR__, "..", "examples/bickley.jl"), OUTPUT;
-    execute=false,preprocess=preprocess_notebook)
+    execute=false, preprocess=preprocess_notebook)
 Literate.script(joinpath(@__DIR__, "..", "examples/bickley.jl"), OUTPUT;
-    preprocess=preprocess_script
-    )
+    preprocess=preprocess_script)
 Literate.script(joinpath(@__DIR__, "..", "examples/bickley.jl"), "/tmp/";
-    preprocess=preprocess_script2
-    )
+    preprocess=preprocess_script2)
 
 run(`julia --project=docs/ /tmp/bickley.jl`)
 
 Literate.markdown(joinpath(@__DIR__, "..", "examples/trajectories.jl"), OUTPUT;
-    documenter=false,preprocess=preprocess_markdown)
+    documenter=false, preprocess=preprocess_markdown)
 Literate.notebook(joinpath(@__DIR__, "..", "examples/trajectories.jl"), OUTPUT;
-    execute=false,preprocess=preprocess_notebook)
+    execute=false, preprocess=preprocess_notebook)
 Literate.script(joinpath(@__DIR__, "..", "examples/trajectories.jl"), OUTPUT;
-    preprocess=preprocess_script
-    )
+    preprocess=preprocess_script)
 Literate.script(joinpath(@__DIR__, "..", "examples/trajectories.jl"), "/tmp/";
-    preprocess=preprocess_script2
-    )
+    preprocess=preprocess_script2)
 
 run(`julia --project=docs/ /tmp/trajectories.jl`)
 
-
-
 Literate.markdown(joinpath(@__DIR__, "..", "examples/ocean_flow.jl"), OUTPUT;
-    documenter=false,preprocess=preprocess_markdown)
+    documenter=false, preprocess=preprocess_markdown)
 Literate.notebook(joinpath(@__DIR__, "..", "examples/ocean_flow.jl"), OUTPUT;
-    execute=false,preprocess=preprocess_notebook)
+    execute=false, preprocess=preprocess_notebook)
 Literate.script(joinpath(@__DIR__, "..", "examples/ocean_flow.jl"), OUTPUT;
-    preprocess=preprocess_script
-    )
+    preprocess=preprocess_script)
 Literate.script(joinpath(@__DIR__, "..", "examples/ocean_flow.jl"), "/tmp/";
-    preprocess=preprocess_script2
-    )
+    preprocess=preprocess_script2)
 
 run(`julia --project=docs/ /tmp/ocean_flow.jl`)
 
 Literate.markdown(joinpath(@__DIR__, "..", "examples/rot_double_gyre.jl"), OUTPUT;
-    documenter=false,preprocess=preprocess_markdown)
+    documenter=false, preprocess=preprocess_markdown)
 Literate.notebook(joinpath(@__DIR__, "..", "examples/rot_double_gyre.jl"), OUTPUT;
-    execute=false,preprocess=preprocess_notebook)
+    execute=false, preprocess=preprocess_notebook)
 Literate.script(joinpath(@__DIR__, "..", "examples/rot_double_gyre.jl"), OUTPUT;
-    preprocess=preprocess_script
-    )
+    preprocess=preprocess_script)
 Literate.script(joinpath(@__DIR__, "..", "examples/rot_double_gyre.jl"), "/tmp/";
-    preprocess=preprocess_script2
-    )
+    preprocess=preprocess_script2)
 
 run(`julia --project=docs/ /tmp/rot_double_gyre.jl`)
 
-
 Literate.markdown(joinpath(@__DIR__, "..", "examples/standard_map.jl"), OUTPUT;
-    documenter=false,preprocess=preprocess_markdown)
+    documenter=false, preprocess=preprocess_markdown)
 Literate.notebook(joinpath(@__DIR__, "..", "examples/standard_map.jl"), OUTPUT;
-    execute=false,preprocess=preprocess_notebook)
+    execute=false, preprocess=preprocess_notebook)
 Literate.script(joinpath(@__DIR__, "..", "examples/standard_map.jl"), OUTPUT;
-    preprocess=preprocess_script
-    )
+    preprocess=preprocess_script)
 Literate.script(joinpath(@__DIR__, "..", "examples/standard_map.jl"), "/tmp/";
-    preprocess=preprocess_script2
-    )
+    preprocess=preprocess_script2)
 
 run(`julia --project=docs/ /tmp/standard_map.jl`)
-
-
 
 # replace links (if any)
 # travis_tag = get(ENV, "TRAVIS_TAG", "")

--- a/docs/makeimages.jl
+++ b/docs/makeimages.jl
@@ -19,9 +19,8 @@ inverse_flow_map_t = (t,u0) -> flow(rot_double_gyre,u0,[t,0.0])[end]
 @everywhere u2 = nodal_interpolation(ctx2,checkerboard)
 @everywhere uf(t) = u2
 extra_kwargs_fun = t->  [(:title, @sprintf("Rotating Double Gyre, t=%.2f", t))]
-res = CoherentStructures.eulerian_video(ctx2,uf,inverse_flow_map_t,
-    0.0,1.0, 500,500,100, [0.0,0.0],[1.0,1.0],colorbar=false,
-    extra_kwargs_fun=extra_kwargs_fun)
+res = eulerian_video(ctx2, uf, inverse_flow_map_t, 0.0, 1.0, 500, 500, 100, [0.0,0.0], [1.0,1.0],
+    colorbar=false, extra_kwargs_fun=extra_kwargs_fun)
 Plots.mp4(res ,"docs/buildimg/rotdoublegyre.mp4")
 
 LL = [0.0,0.0]; UR = [1.0,1.0];
@@ -50,7 +49,7 @@ pred  = (x,y) -> ((x[1] - y[1]) % 2π) < 1e-9 && ((x[2] - y[2]) % 2π) < 1e-9
 bdata = BoundaryData(ctx,pred)
 
 id2 = one(Tensors.Tensor{2,2}) # 2D identity tensor
-cgfun = x -> 0.5*(id2 +  dott(inv(CoherentStructures.DstandardMap(x))))
+cgfun = x -> 0.5*(id2 +  dott(inv(DstandardMap(x))))
 
 K = assembleStiffnessMatrix(ctx,cgfun,bdata=bdata)
 M = assembleMassMatrix(ctx,lumped=false,bdata=bdata)
@@ -65,7 +64,7 @@ for i in 1:50
     srand(i)
     x = rand(2)*2π
     for i in 1:500
-        x = CoherentStructures.standardMap(x)
+        x = standardMap(x)
         push!(orbits,x)
     end
 end

--- a/docs/makeimages.jl
+++ b/docs/makeimages.jl
@@ -38,7 +38,7 @@ Plots.savefig(res2,"docs/buildimg/rotdgev1.png")
 
 ctx = regularQuadrilateralGrid((10,10))
 predicate = (p1,p2) -> abs(p1[2] - p2[2]) < 1e-10 && (abs((p1[1] - p2[1])%1.0) < 1e-10)
-bdata = boundaryData(ctx,predicate,[])
+bdata = BoundaryData(ctx,predicate,[])
 u = ones(nDofs(ctx,bdata))
 u[20] = 2.0; u[38] = 3.0; u[56] = 4.0
 plot_u(ctx,u,200,200,bdata=bdata)
@@ -47,7 +47,7 @@ plot_u(ctx,u,200,200,bdata=bdata)
 using CoherentStructures,Tensors
 ctx = regularTriangularGrid((100,100), [0.0,0.0],[2π,2π])
 pred  = (x,y) -> ((x[1] - y[1]) % 2π) < 1e-9 && ((x[2] - y[2]) % 2π) < 1e-9
-bdata = boundaryData(ctx,pred)
+bdata = BoundaryData(ctx,pred)
 
 id2 = one(Tensors.Tensor{2,2}) # 2D identity tensor
 cgfun = x -> 0.5*(id2 +  dott(inv(CoherentStructures.DstandardMap(x))))

--- a/docs/src/fem.md
+++ b/docs/src/fem.md
@@ -183,7 +183,7 @@ adaptiveTOCollocationStiffnessMatrix
 There are several helper functions available for constructing grids. The simplest is:
 #### In 1D
 ```@docs
-regular1dGrid
+regular1dP1Grid
 regular1dP2Grid
 ```
 ### In 2D

--- a/docs/src/fem.md
+++ b/docs/src/fem.md
@@ -107,7 +107,7 @@ function.
 ## Boundary Conditions
 
 To use something other than the natural homogeneous von Neumann boundary
-conditions, the `CoherentStructures.BoundaryData` type can be used. This currently
+conditions, the `BoundaryData` type can be used. This currently
 supports combinations of homogeneous Dirichlet and periodic boundary conditions.
  - Homogeneous Dirichlet BCs require rows and columns of the stiffness/mass
    matrices to be deleted
@@ -193,7 +193,7 @@ regular2dGrid
 Supported values for the `gridType` argument are:
 ```@example
 using CoherentStructures #hide
-CoherentStructures.regular2dGridTypes
+regular2dGridTypes
 ```
 The following functions are conceptually similar:
 ```@docs

--- a/docs/src/fem.md
+++ b/docs/src/fem.md
@@ -55,13 +55,13 @@ Various types of regular and irregular meshes (with Delaunay triangulation using
  - triangular and quadrilateral P2-Lagrange elements in 2D (all methods except adaptive TO)
  - tetrahedral P1-Lagrange elements in 3D (only CG method tested, non-adaptive TO might work also)
 
-## The `gridContext` Type
+## The `GridContext` Type
 
 The FEM-based methods of `CoherentStructures.jl` rely heavily on the [JuAFEM.jl](https://github.com/KristofferC/JuAFEM.jl) package.
 This package is very low-level and does not provide point-location/plotting functionality.
-To be able to more conveniently work with the specific types of grids that we need, all necessary variables for a single grid are combined in a `gridContext` structure - including the grid points, the quadrature formula used and the type of element used (e.g. Triangular P1, Quadrilateral P2, etc..). This makes it easier to assemble mass/stiffness matrices, and provides an interface for point-location and plotting.
+To be able to more conveniently work with the specific types of grids that we need, all necessary variables for a single grid are combined in a `GridContext` structure - including the grid points, the quadrature formula used and the type of element used (e.g. Triangular P1, Quadrilateral P2, etc..). This makes it easier to assemble mass/stiffness matrices, and provides an interface for point-location and plotting.
 
-In this documentation, the variable name `ctx` is exclusively used for `gridContext` objects.
+In this documentation, the variable name `ctx` is exclusively used for `GridContext` objects.
 
 See also [Constructing Grids](@ref) in the [FEM-API](@ref) section.
 
@@ -74,7 +74,7 @@ The nodes of the grid can be obtained in the following way `[n.x for n in ctx.gr
 However, most of the methods of this package do _not_ return results in this order, but instead
 use `JuAFEM.jl`'s dof-ordering.
 
-See also the documentation in [`dof2node`](@ref) and [`CoherentStructures.gridContext`](@ref)
+See also the documentation in [`dof2node`](@ref) and [`CoherentStructures.GridContext`](@ref)
 
 When working with (non-natural) [Boundary Conditions](@ref), the ordering is further changed, due to there being fewer degrees of freedom in total.
 
@@ -107,7 +107,7 @@ function.
 ## Boundary Conditions
 
 To use something other than the natural homogeneous von Neumann boundary
-conditions, the `CoherentStructures.boundaryData` type can be used. This currently
+conditions, the `CoherentStructures.BoundaryData` type can be used. This currently
 supports combinations of homogeneous Dirichlet and periodic boundary conditions.
  - Homogeneous Dirichlet BCs require rows and columns of the stiffness/mass
    matrices to be deleted
@@ -122,21 +122,21 @@ account.
 ### Constructing Boundary Conditions
 
 Natural von-Neumann boundary conditions can be constructed with:
-`boundaryData()` and are generally the default
+`BoundaryData()` and are generally the default
 
 Homogeneous Dirichlet boundary conditions can be constructed with the
 `getHomDBCS(ctx[, which="all"])` function. The optional `which` parameter is a
 vector of strings, corresponding to `JuAFEM` face-sets, e.g.
 `getHomDBCS(ctx, which=["left", "right"])`
 
-Periodic boundary conditions are constructed by calling `boundaryData(ctx,predicate,[which_dbc=[]])`. The argument `predicate` is a
+Periodic boundary conditions are constructed by calling `BoundaryData(ctx,predicate,[which_dbc=[]])`. The argument `predicate` is a
 function that should return `true` if and only if two points should be identified.
 Due to floating-point rounding errors, note that using exact comparisons (`==`)
 should be avoided. Only points that are in `JuAFEM.jl` boundary facesets are
 considered. If this is too restrictive, use the
-`boundaryData(dbc_dofs, periodic_dofs_from, periodic_dofs_to)` constructor.
+`BoundaryData(dbc_dofs, periodic_dofs_from, periodic_dofs_to)` constructor.
 
-For details, see [`boundaryData`](@ref).
+For details, see [`BoundaryData`](@ref).
 
 ### Example
 
@@ -145,7 +145,7 @@ Here we apply homogeneous DBC to top and bottom, and identify the left and right
 using CoherentStructures, Distances, Plots
 ctx, _ = regularQuadrilateralGrid((10, 10))
 predicate = (p1, p2) -> peuclidean(p1, p2, [1.0, Inf]) < 2e-10
-bdata = boundaryData(ctx, predicate, ["top", "bottom"])
+bdata = BoundaryData(ctx, predicate, ["top", "bottom"])
 u = ones(nBCDofs(ctx, bdata))
 u[20] = 2.0; u[38] = 3.0; u[56] = 4.0
 plot_u(ctx, u, 200, 200, bdata=bdata, colorbar=:none)
@@ -210,15 +210,15 @@ In 3D we have
 regularTetrahedralGrid
 regularP2TetrahedralGrid
 ```
-All of these methods return a `gridContext` object and a `boundaryData` object. The latter is only relevant when using
+All of these methods return a `GridContext` object and a `BoundaryData` object. The latter is only relevant when using
 a Delaunay grid with `on_torus==true`.
 ```@docs
-CoherentStructures.gridContext
+CoherentStructures.GridContext
 ```
 
 ### Boundary Conditions API
 ```@docs
-boundaryData
+BoundaryData
 getHomDBCS
 undoBCS
 applyBCS

--- a/examples/OceanFlow.jl
+++ b/examples/OceanFlow.jl
@@ -9,11 +9,11 @@ using Distributed,JLD2
     t_initial = minimum(Time)
     t_final = t_initial + 90
 
-    LL = [-4.0,-34.0]
-    UR = [6.0,-28.0]
-    UI, VI = interpolateVF(Lon,Lat,Time,UT,VT)
-    p = (UI,VI)
-    ctx = regularP2TriangularGrid((100,60),LL,UR,quadrature_order=2)
+    LL = (-4.0, -34.0)
+    UR = (6.0, -28.0)
+    UI, VI = interpolateVF(Lon, Lat, Time, UT, VT)
+    p = (UI, VI)
+    ctx = regularP2TriangularGrid((100, 60), LL, UR, quadrature_order=2)
 
     # ctx.mass_weights = [cos(deg2rad(x[2])) for x in ctx.quadrature_points]
     times = [t_initial,t_final]
@@ -22,16 +22,16 @@ end
 ####### for comparison, finally only one of the following lines should remain #######
 # seems like mean(pullback_diffusion_tensor) is no worse than mean_diff_tensor, maybe even faster
 # first the not-in-place SVector versions
-@everywhere mdt(x) = mean_diff_tensor(interp_rhs, x,times, 1.e-8,tolerance=1.e-5,p=p)
+@everywhere mdt(x) = mean_diff_tensor(interp_rhs, x, times, 1.e-8, tolerance=1.e-5, p=p)
 @time As = [mdt(x) for x in ctx.quadrature_points]
-@time As = pmap(mdt,ctx.quadrature_points)
+@time As = pmap(mdt, ctx.quadrature_points)
 @time As = parallel_tensor(mdt,ctx.quadrature_points)
 
 # now the mutating
-@everywhere mdt!(x) = mean_diff_tensor(interp_rhs!, x,times, 1.e-8,tolerance=1.e-5,p=p)
+@everywhere mdt!(x) = mean_diff_tensor(interp_rhs!, x, times, 1.e-8, tolerance=1.e-5, p=p)
 @time As = [mdt!(x) for x in ctx.quadrature_points]
-@time As = pmap(mdt!,ctx.quadrature_points)
-@time As = parallel_tensor(mdt!,ctx.quadrature_points)
+@time As = pmap(mdt!, ctx.quadrature_points)
+@time As = parallel_tensor(mdt!, ctx.quadrature_points)
 ######### end of comparison
 
 mean_As = As
@@ -44,55 +44,55 @@ end
 #With CG-Method
 begin
     q = [mean_As]
-    bdata = CoherentStructures.getHomDBCS(ctx)
-    @time K2 = assembleStiffnessMatrix(ctx,mean_Afun,q,bdata=bdata)
-    @time M2 = assembleMassMatrix(ctx,bdata=bdata)
-    @time λ2, v2 = eigs(K2,M2,which=:SM,nev=6)
+    bdata = getHomDBCS(ctx)
+    @time K2 = assembleStiffnessMatrix(ctx, mean_Afun, q, bdata=bdata)
+    @time M2 = assembleMassMatrix(ctx, bdata=bdata)
+    @time λ2, v2 = eigs(K2, M2, which=:SM, nev=6)
 end
 plot_real_spectrum(λ2)
-plot_u(ctx,v2[:,6],200,200,bdata=bdata,color=:rainbow)
+plot_u(ctx, v2[:,6], 200, 200, bdata=bdata, color=:rainbow)
 length(bdata.dbc_dofs)
 using Clustering
 numclusters = 5
-res = kmeans(permutedims(v2[:,1:numclusters]),numclusters+1)
+res = kmeans(permutedims(v2[:,1:numclusters]), numclusters+1)
 u = kmeansresult2LCS(res)
-plot_u(ctx,u[:,3],200,200,color=:viridis)
+plot_u(ctx, u[:,3], 200, 200, color=:viridis)
 
 ##Make a video of the LCS being advected
 
 #Inverse-flow map at time t
-inverse_flow_map_t = (t,u0) -> flow(interp_rhs!,u0,
-        [t,t_initial],p=(UI,VI),tolerance=1e-4)[end]
+inverse_flow_map_t = (t,u0) -> flow(interp_rhs!, u0,
+        [t, t_initial], p=(UI, VI), tolerance=1e-4)[end]
 #Function u(t), here it is just constant
 current_u = t -> u[:,2]
 #Where to plot the video
-LL_big = [-10,-40.0]
-UR_big = [6,-25.0]
+LL_big = (-10, -40.0)
+UR_big = (6, -25.0)
 #Make the video
-res = CoherentStructures.eulerian_video(ctx,current_u,LL_big,UR_big,
-        100,100,t_initial, t_final, #nx = 100, ny=100
-        30,inverse_flow_map_t)#nt = 20
+res = eulerian_video(ctx,current_u, LL_big, UR_big,
+        100, 100, t_initial, t_final, #nx = 100, ny=100
+        30, inverse_flow_map_t)#nt = 20
 #Save it
 Plots.mp4(res,"/tmp/output.mp4")
 
 using Arpack
 using Plots
 
-ctx = regularDelaunayGrid((100,60),LL,UR,quadrature_order=2)
+ctx = regularDelaunayGrid((100, 60), LL, UR, quadrature_order=2)
 #With adaptive TO method
 begin
-    ocean_flow_map = u0 -> flow(interp_rhs,u0, [t_initial,t_final],p=(UI,VI),tolerance=1e-5)[end]
+    ocean_flow_map = u0 -> flow(interp_rhs, u0, [t_initial, t_final], p=(UI, VI), tolerance=1e-5)[end]
     @time S = assembleStiffnessMatrix(ctx)
     @time M = assembleMassMatrix(ctx)
-    @time S2= adaptiveTO(ctx,ocean_flow_map)
-    @time λ, v = eigs(S + S2,M,which=:SM)
+    @time S2= adaptiveTO(ctx, ocean_flow_map)
+    @time λ, v = eigs(S + S2, M, which=:SM)
 end
-plot_u(ctx,v[:,1])
+plot_u(ctx, v[:,1])
 Plots.gr()
 I, J, V = findnz(S)
-Plots.scatter(I,J,markersize=0.1)
+Plots.scatter(I, J, markersize=0.1)
 V .= 1 .- V
-S3 = sparse(I,J,V)
+S3 = sparse(I, J, V)
 Plots.heatmap(S3,clim=(0.0,1.0))
 Plots.pdf("/tmp/heatmap.pdf")
 

--- a/examples/abc.jl
+++ b/examples/abc.jl
@@ -7,7 +7,7 @@ abcctx = CoherentStructures.regularP2TetrahedralGrid((5, 5, 5), [0.0, 0.0, 0.0],
     [2π, 2π, 2π], quadrature_order=2)
 bdata_predicate = (x,y) -> peuclidean(x, y, [2π, 2π, 2π]) < 1e-8
 
-bdata = boundaryData(abcctx, bdata_predicate)
+bdata = BoundaryData(abcctx, bdata_predicate)
 
 cgfun = x-> mean_diff_tensor(abcFlow, x, [0.0,1.0], 1.e-10, p=(√3,√2,1), tolerance=1.e-3)
 @time M = assembleMassMatrix(abcctx, bdata=bdata);

--- a/examples/bickley.jl
+++ b/examples/bickley.jl
@@ -92,10 +92,10 @@ DISPLAY_PLOT(fig, bickley_geodesic_vortices)
 # as described above. We are working on a periodic domain in one direction:
 
 using Distances
-LL = [0.0, -3.0]; UR = [6.371π, 3.0]
+LL = (0.0, -3.0); UR = (6.371π, 3.0)
 ctx, _ = regularP2TriangularGrid((50, 15), LL, UR, quadrature_order=2)
-predicate = (p1,p2) -> abs(p1[2] - p2[2]) < 1e-10 && peuclidean(p1[1], p2[1], 6.371π) < 1e-10
-bdata = CoherentStructures.boundaryData(ctx, predicate, []);
+predicate = (p1, p2) -> peuclidean(p1, p2, [6.371π, Inf]) < 1e-10
+bdata = BoundaryData(ctx, predicate, []);
 
 # Using a FEM-based method to compute coherent structures:
 

--- a/examples/bickley_with_macro.jl
+++ b/examples/bickley_with_macro.jl
@@ -4,7 +4,7 @@ nx, ny = 100, 31
 LL = [0.0, -3.0]; UR=[6.371π, 3.0]
 ctx, _ = regularTriangularGrid((nx, ny), LL, UR, quadrature_order=2)
 predicate = (x,y) -> (abs(x[2] - y[2]) < 1e-10) && (peuclidean(x[1],y[1],6.371π) < 1e-10)
-bdata = CoherentStructures.boundaryData(ctx, predicate, [])
+bdata = CoherentStructures.BoundaryData(ctx, predicate, [])
 
 cgfun = (x -> mean_diff_tensor(bickleyJet, x, range(0.0,stop=40*3600*24,length=81),
      1.e-8, tolerance=1.e-6, solver=Tsit5()))

--- a/examples/bickley_with_macro.jl
+++ b/examples/bickley_with_macro.jl
@@ -3,15 +3,15 @@ using CoherentStructures, OrdinaryDiffEq, Arpack
 nx, ny = 100, 31
 LL = [0.0, -3.0]; UR=[6.371π, 3.0]
 ctx, _ = regularTriangularGrid((nx, ny), LL, UR, quadrature_order=2)
-predicate = (x,y) -> (abs(x[2] - y[2]) < 1e-10) && (peuclidean(x[1],y[1],6.371π) < 1e-10)
-bdata = CoherentStructures.BoundaryData(ctx, predicate, [])
+predicate = (x, y) -> peuclidean(x, y, [6.371π, Inf]) < 1e-10
+bdata = BoundaryData(ctx, predicate, [])
 
 cgfun = (x -> mean_diff_tensor(bickleyJet, x, range(0.0,stop=40*3600*24,length=81),
      1.e-8, tolerance=1.e-6, solver=Tsit5()))
 
 @time K = assembleStiffnessMatrix(ctx, cgfun, bdata=bdata)
 @time M = assembleMassMatrix(ctx, bdata=bdata)
-@time λ, v = Arpack.eigs(K, M, which=:SM, nev= 10)
+@time λ, v = eigs(K, M, which=:SM, nev= 10)
 
 plot_u(ctx, v[:,2], 4nx, 4ny, bdata=bdata)
 plot_real_spectrum(λ)

--- a/examples/ocean_flow.jl
+++ b/examples/ocean_flow.jl
@@ -142,8 +142,8 @@ flow_map = u0 -> flow(interp_rhs, u0, times;
 
 # Next, we set up the domain. We want to use zero Dirichlet boundary conditions here.
 
-LL = [-4.0, -34.0]
-UR = [6.0, -28.0]
+LL = (-4.0, -34.0)
+UR = (6.0, -28.0)
 ctx, _  = regularTriangularGrid((150, 90), LL, UR)
 bdata = getHomDBCS(ctx, "all");
 

--- a/examples/rot_double_gyre.jl
+++ b/examples/rot_double_gyre.jl
@@ -32,7 +32,7 @@
 # The following code demonstrates how to use these methods.
 
 using CoherentStructures, Arpack
-LL = [0.0, 0.0]; UR = [1.0, 1.0];
+LL, UR = (0.0, 0.0), (1.0, 1.0)
 ctx, _ = regularTriangularGrid((50, 50), LL, UR)
 
 A = x -> mean_diff_tensor(rot_double_gyre, x, [0.0, 1.0], 1.e-10, tolerance= 1.e-4)

--- a/examples/standard_map.jl
+++ b/examples/standard_map.jl
@@ -23,24 +23,24 @@
 
 using Random
 
-a = 0.971635
-f(a,x) = (mod2pi(x[1] + x[2] + a*sin(x[1])),
-          mod2pi(x[2] + a*sin(x[1])))
+const a = 0.971635
+f(x) = (rem2pi(x[1] + x[2] + a*sin(x[1]), RoundDown),
+          rem2pi(x[2] + a*sin(x[1]), RoundDown))
 
-X = []
+X = Tuple{Float64,Float64}[]
 for i in 1:50
     Random.seed!(i)
-    x = 2π*rand(2)
+    x = 2π .* (rand(), rand())
     for i in 1:500
-        x = f(a,x)
+        x = f(x)
         push!(X,x)
     end
 end
 
 using Plots
 gr(aspect_ratio=1, legend=:none)
-fig = scatter([x[1] for x in X], [x[2] for x in X], markersize=1)
-DISPLAY_PLOT(fig,standard_map_orbits)
+fig = scatter(X, markersize=1)
+DISPLAY_PLOT(fig, standard_map_orbits)
 
 # Approximating the Dynamic Laplacian by FEM methods is straightforward:
 
@@ -48,10 +48,10 @@ using Arpack, CoherentStructures, Distances, Tensors
 
 Df(a,x) = Tensor{2,2}((1.0+a*cos(x[1]), a*cos(x[1]), 1.0, 1.0))
 
-n, ll, ur = 100, [0.0, 0.0], [2π, 2π]               # grid size, domain corners
+n, ll, ur = 100, (0.0, 0.0), (2π, 2π)               # grid size, domain corners
 ctx, _ = regularTriangularGrid((n, n), ll, ur)
-pred(x,y) = peuclidean(x, y, ur) < 1e-9
-bd = boundaryData(ctx, pred)                      # periodic boundary
+pred(x,y) = peuclidean(x, y, [2π, 2π]) < 1e-9
+bd = BoundaryData(ctx, pred)                      # periodic boundary
 
 I = one(Tensor{2,2})                              # identity matrix
 Df2(x) = Df(a,f(a,x))⋅Df(a,x)                     # consider 2. iterate

--- a/examples/standard_map.jl
+++ b/examples/standard_map.jl
@@ -46,16 +46,16 @@ DISPLAY_PLOT(fig, standard_map_orbits)
 
 using Arpack, CoherentStructures, Distances, Tensors
 
-Df(a,x) = Tensor{2,2}((1.0+a*cos(x[1]), a*cos(x[1]), 1.0, 1.0))
+Df(x) = Tensor{2,2}((1.0+a*cos(x[1]), a*cos(x[1]), 1.0, 1.0))
 
-n, ll, ur = 100, (0.0, 0.0), (2π, 2π)               # grid size, domain corners
+n, ll, ur = 100, (0.0, 0.0), (2π, 2π)       # grid size, domain corners
 ctx, _ = regularTriangularGrid((n, n), ll, ur)
 pred(x,y) = peuclidean(x, y, [2π, 2π]) < 1e-9
-bd = BoundaryData(ctx, pred)                      # periodic boundary
+bd = BoundaryData(ctx, pred)                # periodic boundary
 
-I = one(Tensor{2,2})                              # identity matrix
-Df2(x) = Df(a,f(a,x))⋅Df(a,x)                     # consider 2. iterate
-cg(x) = 0.5*(I + dott(inv(Df2(x))))               # avg. inv. Cauchy-Green tensor
+I = one(Tensor{2,2})                        # identity matrix
+Df2(x) = Df(f(x))⋅Df(x)                     # consider 2. iterate
+cg(x) = 0.5*(I + dott(inv(Df2(x))))         # avg. inv. Cauchy-Green tensor
 
 K = assembleStiffnessMatrix(ctx, cg, bdata=bd)
 M = assembleMassMatrix(ctx, bdata=bd)

--- a/examples/trajectories.jl
+++ b/examples/trajectories.jl
@@ -160,7 +160,7 @@ n = 500
 tspan = range(0, stop=1.0, length=20)
 xs, ys = rand(n), rand(n)
 particles = SVector{2}.(xs, ys)
-trajectories = [flow(rot_double_gyre, particles[i], tspan) for i in 1:n]
+trajectories = [flow(rot_double_gyre, p, tspan) for p in particles]
 
 # Based on the initial particle positions we generate a triangulation.
 # If this call fails or does not return, the initial positions may not be unique.
@@ -168,8 +168,7 @@ trajectories = [flow(rot_double_gyre, particles[i], tspan) for i in 1:n]
 
 ctx, _ = irregularDelaunayGrid(Vec{2}.(particles))
 
-# Next, we generate the stiffness and mass matrices and solve the generalized
-# eigenproblem.
+# Next, we generate the stiffness and mass matrices and solve the generalized eigenproblem.
 
 S = adaptiveTOCollocationStiffnessMatrix(ctx, (i, ts) -> trajectories[i], tspan; flow_map_mode=1)
 M = assembleMassMatrix(ctx)
@@ -202,12 +201,14 @@ clusters = iterated_kmeans(20, permutedims(V[:, 2:partitions]), partitions)
 
 # A simple scatter plot visualization looks as follows.
 
-fig = scatter(xs, ys, zcolor=clusters[ctx.node_to_dof], markersize=8)
+fig = scatter(xs, ys, zcolor=clusters[ctx.node_to_dof], markersize=8, labels="")
 DISPLAY_PLOT(fig, trajectories_fem_scatter)
 
 # Alternatively, we may also plot the cluster assignments on the whole irregular
 # grid.
 
 fig = plot_u(ctx, float(clusters), 400, 400;
-    color=:viridis, colorbar=:none, title="$partitions-partition of rotating double gyre")
+                color=:viridis,
+                colorbar=:none,
+                title="$partitions-partition of rotating double gyre")
 DISPLAY_PLOT(fig, trajectories_fem)

--- a/examples/trajectories.jl
+++ b/examples/trajectories.jl
@@ -176,10 +176,10 @@ M = assembleMassMatrix(ctx)
 using Arpack
 λ, V = eigs(S, M; which=:SM, nev=6)
 
-# We can plot the spectrum obtained.
+# We can plot the computed spectrum.
 
 using Plots
-fig = plot_real_spectrum(λ)
+fig = plot_real_spectrum(λ, label="")
 DISPLAY_PLOT(fig, spectrum_to_laplace)
 
 # We may extract coherent vortices with k-means clustering.

--- a/src/CoherentStructures.jl
+++ b/src/CoherentStructures.jl
@@ -60,7 +60,7 @@ include("diffusion_operators.jl")
 include("dynamicmetrics.jl")
 
 # some utility functions that are used throughout
-abstract type abstractGridContext{dim} end
+abstract type AbstractGridContext{dim} end
 include("util.jl")
 
 # functions related to pulling back tensors under flow maps
@@ -84,11 +84,11 @@ include("isoperimetry.jl")
 ##Extensions to JuAFEM dealing with non-curved grids
 ##Support for evaluating functions at grid points, delaunay Triangulations
 
-#The pointLocator provides an abstract basis class for classes for locating points on grids.
-#A pointLocator should implement a locatePoint function (see below)
+#The PointLocator provides an abstract basis class for classes for locating points on grids.
+#A PointLocator should implement a locatePoint function (see below)
 #TODO: Find out the existence of such a function can be enforced by julia
 
-abstract type pointLocator end
+abstract type PointLocator end
 include("gridfunctions.jl")
 include("pointlocation.jl")
 include("boundaryconditions.jl")

--- a/src/FEMassembly.jl
+++ b/src/FEMassembly.jl
@@ -2,95 +2,63 @@
 # extended by Nathanael Schilling
 
 #Works in n=2 and n=3
-function tensorIdentity(x::Vec{dim}, i::Int, p) where dim
-        return one(SymmetricTensor{2, dim, Float64, 3*(dim-1)})
-end
-
+tensorIdentity(x::Vec{dim}, _, p) where {dim} = one(SymmetricTensor{2,dim,Float64,3(dim-1)})
 
 """
-    assembleStiffnessMatrix(ctx,A,[p; bdata])
+    assembleStiffnessMatrix(ctx, A, p=nothing; bdata=BoundaryData())
 
 Assemble the stiffness-matrix for a symmetric bilinear form
 ```math
-a(u,v) = \\int \\nabla u(x)\\cdot A(x)\\nabla v(x)f(x) dx
+a(u,v) = \\int \\nabla u(x)\\cdot A(x)\\nabla v(x)f(x) dx.
 ```
-The integral is approximated using quadrature.
-`A` is a function that returns a `SymmetricTensor{2,dim}` and has one of the following forms:
-   * `A(x::Vector{Float64})`
-   * `A(x::Vec{dim})`
-   * `A(x::Vec{dim}, index::Int, p)`. Here x is equal to `ctx.quadrature_points[index]`, and `p` is that which is passed to `assembleStiffnessMatrix`
+The integral is approximated using numerical quadrature. `A` is a function that returns a
+`SymmetricTensor{2,dim}` object and must have one of the following signatures:
+   * `A(x::Vector{Float64})`;
+   * `A(x::Vec{dim})`;
+   * `A(x::Vec{dim}, index::Int, p)`. Here, `x` is equal to `ctx.quadrature_points[index]`,
+     and `p` is the one passed to `assembleStiffnessMatrix`.
 
-The ordering of the result is in dof order, except that boundary conditions from `bdata` are applied. The default is natural boundary conditions.
+The ordering of the result is in dof order, except that boundary conditions from `bdata` are
+applied. The default is natural (homogeneous Neumann) boundary conditions.
 """
-function assembleStiffnessMatrix(
-        ctx::gridContext{dim},
-        A::Function=tensorIdentity,
-        p=nothing;
-        bdata=boundaryData() #Default to natural BCs
-        ) where  dim
-
-        Aqcoords = zero(SymmetricTensor{2, dim, Float64})
-        CoherentStructures.assembleStiffnessMatrixInternal(ctx, A, p, Aqcoords, bdata=bdata)
+function assembleStiffnessMatrix(ctx::GridContext, A=tensorIdentity, p=nothing; bdata=BoundaryData())
+    if A === tensorIdentity
+        return _assembleStiffnessMatrix(ctx, A, p, bdata=bdata)
+    elseif !isempty(methods(A, (Vec,)))
+        return _assembleStiffnessMatrix(ctx, (qp, i, p) -> A(qp), p, bdata=bdata)
+    elseif !isempty(methods(A, (Vec, Int, Any)))
+        return _assembleStiffnessMatrix(ctx, (qp, i, p) -> A(qp, i, p), p, bdata=bdata)
+    elseif !isempty(methods(A, (Vector{Float64},)))
+        return _assembleStiffnessMatrix(ctx, (qp, i, p) -> A(Vector{Float64}(qp)), p, bdata=bdata)
+    end
+    error("Function parameter A does not accept types supported by assembleStiffnessMatrix")
 end
 
-"""
-    assembleStiffnessMatrixInternal(ctx,A,p,Aqcoords2; bdata=boundaryData())
+function _assembleStiffnessMatrix(ctx::GridContext, A, p; bdata=BoundaryData())
+    cv = JFM.CellScalarValues(ctx.qr, ctx.ip, ctx.ip_geom)
+    dh = ctx.dh
+    K = JFM.create_sparsity_pattern(dh)
+    a_K = JFM.start_assemble(K)
+    dofs = zeros(Int, JFM.ndofs_per_cell(dh))
+    n = JFM.getnbasefunctions(cv)         # number of basis functions
+    Ke = zeros(n, n)
 
-This function implements the functionality of `assembleStiffnessMatrix`.
-It is in a separate function for performance reasons to create a function barrier.
-"""
-function assembleStiffnessMatrixInternal(
-        ctx::gridContext{dim},
-        A::Function,
-        p,
-        Aqcoords2::T,
-        ;
-        bdata=boundaryData() #Default to natural BCs
-        ) where {T,dim}
-    cv::JFM.CellScalarValues{dim} = JFM.CellScalarValues(ctx.qr, ctx.ip, ctx.ip_geom)
-    dh::JFM.DofHandler{dim} = ctx.dh
-    K::SparseMatrixCSC{Float64,Int64} = JFM.create_sparsity_pattern(dh)
-    a_K::JFM.AssemblerSparsityPattern{Float64,Int64} = JFM.start_assemble(K)
-    dofs::Vector{Int} = zeros(Int, JFM.ndofs_per_cell(dh))
-    n::Int64 = JFM.getnbasefunctions(cv)         # number of basis functions
-    Ke::Array{Float64,2} = zeros(n, n)
-    index::Int = 1 #Counter to know the number of the current quadrature point
-    A_type::Int = 0 #What type of function A is.
-    if A == tensorIdentity
-        A_type = 3
-    elseif !isempty(methods(A,(Vec{dim},)))
-        A_type = 0
-    elseif !isempty(methods(A,(Vec{dim},Int,Any)))
-        A_type = 1
-    elseif !isempty(methods(A,(Vector{Float64},)))
-        A_type = 2
-    else
-        fail("Function parameter A does not accept types supported by assembleStiffnessMatrix")
-    end
+    index = 1 # quadrature point counter
 
-    Aqcoords::T = zero(T)
     @inbounds for (cellcount, cell) in enumerate(JFM.CellIterator(dh))
         fill!(Ke, 0)
         JFM.reinit!(cv, cell)
         for q in 1:JFM.getnquadpoints(cv) # loop over quadrature points
-            if A_type == 0
-                Aqcoords = A(ctx.quadrature_points[index])
-            elseif A_type == 1
-                Aqcoords = A(ctx.quadrature_points[index], index, p)
-            elseif A_type == 2
-                Aqcoords = A(Vector{Float64}(ctx.quadrature_points[index]))
-            elseif A_type == 3
-                Aqcoords = one(SymmetricTensor{2, dim, Float64, 3*(dim-1)})
-            end
-            dΩ::Float64 = JFM.getdetJdV(cv, q) * ctx.mass_weights[index]
+            Aq = A(ctx.quadrature_points[index], index, p)
+            dΩ = JFM.getdetJdV(cv, q) * ctx.mass_weights[index]
             for i in 1:n
-                ∇φ::Vec{dim,Float64} = JFM.shape_gradient(cv, q, i)
+                ∇φ = JFM.shape_gradient(cv, q, i)
                 for j in 1:(i-1)
-                    ∇ψ::Vec{dim,Float64} = JFM.shape_gradient(cv, q, j)
-                    Ke[i,j] -= (∇φ ⋅ (Aqcoords ⋅ ∇ψ)) * dΩ
-                    Ke[j,i] -= (∇φ ⋅ (Aqcoords ⋅ ∇ψ)) * dΩ
+                    ∇ψ = JFM.shape_gradient(cv, q, j)
+                    Ke[i,j] -= (∇φ ⋅ (Aq ⋅ ∇ψ)) * dΩ
+                    Ke[j,i] -= (∇φ ⋅ (Aq ⋅ ∇ψ)) * dΩ
                 end
-                Ke[i,i] -= (∇φ ⋅ (Aqcoords ⋅ ∇φ)) * dΩ
+                Ke[i,i] -= (∇φ ⋅ (Aq ⋅ ∇φ)) * dΩ
             end
             index += 1
         end
@@ -102,19 +70,18 @@ end
 
 
 """
-    assembleMassMatrix(ctx;[bdata,lumped=false])
+    assembleMassMatrix(ctx; bdata=BoundaryData(), lumped=false)
 
 Assemble the mass matrix
 ```math
 M_{i,j} = \\int \\varphi_j(x) \\varphi_i(x) f(x)d\\lambda^d
 ```
-The integral is approximated using numerical quadrature.
-The values of `f(x)` are taken from `ctx.mass_weights`, and should be ordered in the same way as `ctx.quadrature_points`
+The integral is approximated using numerical quadrature. The values of `f(x)` are taken from
+`ctx.mass_weights`, and should be ordered in the same way as `ctx.quadrature_points`.
 
-The result is ordered in a way so as to be usable with a stiffness matrix
-with boundary data `bdata`.
+The result is ordered to be usable with a stiffness matrix with boundary data `bdata`.
 
-Returns a lumped mass matrix if `lumped==true`.
+Returns a lumped mass matrix if `lumped=true`.
 
 # Example
 ```
@@ -122,30 +89,26 @@ ctx.mass_weights = map(f, ctx.quadrature_points)
 M = assembleMassMatrix(ctx)
 ```
 """
-function assembleMassMatrix(
-        ctx::gridContext{dim};
-        bdata=boundaryData(),
-        lumped=false,
-        ) where dim
-    cv::JFM.CellScalarValues{dim} = JFM.CellScalarValues(ctx.qr, ctx.ip, ctx.ip_geom)
-    dh::JFM.DofHandler{dim} = ctx.dh
-    M::SparseMatrixCSC{Float64,Int64} = JFM.create_sparsity_pattern(dh)
-    a_M::JFM.AssemblerSparsityPattern{Float64,Int64} = JFM.start_assemble(M)
-    dofs::Vector{Int} = zeros(Int, JFM.ndofs_per_cell(dh))
-    n::Int64 = JFM.getnbasefunctions(cv)         # number of basis functions
-    Me::Array{Float64,2} = zeros(n, n)   # Local stiffness and mass matrix
-    index::Int = 1
+function assembleMassMatrix(ctx::GridContext; bdata=BoundaryData(), lumped=false)
+    cv = JFM.CellScalarValues(ctx.qr, ctx.ip, ctx.ip_geom)
+    dh = ctx.dh
+    M = JFM.create_sparsity_pattern(dh)
+    a_M = JFM.start_assemble(M)
+    dofs = zeros(Int, JFM.ndofs_per_cell(dh))
+    n = JFM.getnbasefunctions(cv)         # number of basis functions
+    Me = zeros(n, n)   # Local stiffness and mass matrix
+    index = 1
 
     @inbounds for (cellcount, cell) in enumerate(JFM.CellIterator(dh))
         fill!(Me, 0)
         JFM.reinit!(cv, cell)
         for q in 1:JFM.getnquadpoints(cv) # loop over quadrature points
-            dΩ::Float64 = JFM.getdetJdV(cv, q) * ctx.mass_weights[index]
+            dΩ = JFM.getdetJdV(cv, q) * ctx.mass_weights[index]
             for i in 1:n
-                φ::Float64 = JFM.shape_value(cv, q, i)
+                φ = JFM.shape_value(cv, q, i)
                 for j in 1:(i-1)
-                    ψ::Float64 = JFM.shape_value(cv, q, j)
-                    scalprod::Float64 = (φ ⋅ ψ) * dΩ
+                    ψ = JFM.shape_value(cv, q, j)
+                    scalprod = (φ ⋅ ψ) * dΩ
                     Me[i,j] += scalprod
                     Me[j,i] += scalprod
                 end
@@ -158,17 +121,7 @@ function assembleMassMatrix(
     end
 
     M = applyBCS(ctx, M, bdata)
-
-    if !lumped
-        return M
-    else
-        Mlumped = spdiagm(0 => ones(size(M)[1]))
-        for j = 1:n
-            Mlumped[j,j] = sum(M[:,j])
-        end
-
-        return Mlumped
-    end
+    return lumped ? spdiagm(0 => dropdims(reduce(+, M; dims=1); dims=1)) : M
 end
 
 """
@@ -177,18 +130,17 @@ end
 Compute the coordinates of all quadrature points on a grid.
 Helper function.
 """
-function getQuadPoints(ctx::gridContext{dim}) where dim
-    cv::JFM.CellScalarValues{dim} = JFM.CellScalarValues(ctx.qr, ctx.ip_geom)
-    dh::JFM.DofHandler{dim} = ctx.dh
-    dofs::Vector{Int} = zeros(Int, JFM.ndofs_per_cell(dh))
+function getQuadPoints(ctx::GridContext{dim}) where {dim}
+    cv = JFM.CellScalarValues(ctx.qr, ctx.ip_geom)
+    dh = ctx.dh
     dofs = zeros(Int, JFM.ndofs_per_cell(dh))
     result = Vec{dim,Float64}[]
 
-    n::Int = JFM.getnbasefunctions(cv)         # number of basis functions
+    n = JFM.getnbasefunctions(cv)         # number of basis functions
     @inbounds for (cellcount, cell) in enumerate(JFM.CellIterator(dh))
         JFM.reinit!(cv, cell)
         for q in 1:JFM.getnquadpoints(cv) # loop over quadrature points
-    	    q_coords = zero(Vec{dim})
+    	    q_coords = zero(Vec{dim,Float64})
             for j in 1:n
                 q_coords += cell.coords[j] * cv.M[j,q]
             end

--- a/src/TO.jl
+++ b/src/TO.jl
@@ -21,17 +21,17 @@ The parameter `volume_preserving` determines whether to attempt to correct for
 non-volume-preserving maps.
 """
 function nonAdaptiveTOCollocation(
-        ctx_domain::gridContext{dim},
-        inverse_flow_map::Function,
-        ctx_codomain::gridContext{dim}=ctx_domain;
-        bdata_domain=boundaryData(),
+        ctx_domain::GridContext{dim},
+        inverse_flow_map,
+        ctx_codomain::GridContext{dim}=ctx_domain;
+        bdata_domain=BoundaryData(),
         bdata_codomain=bdata_domain,
         project_in=false,
         outside_value=NaN,
         volume_preserving=true
-    ) where dim
+    ) where {dim}
 
-    @assert isa(ctx_codomain.ip, JuAFEM.Lagrange)
+    @assert isa(ctx_codomain.ip, JFM.Lagrange)
 
     n_codomain = ctx_codomain.n
     n_domain = ctx_domain.n
@@ -102,7 +102,7 @@ function nonAdaptiveTOCollocation(
 end
 
 """
-    adaptiveTOCollocationStiffnessMatrix(ctx,flow_maps,times=nothing; [quadrature_order, on_torus,on_cylinder, LL,UR, bdata, volume_preserving=true,flow_map_mode=0] )
+    adaptiveTOCollocationStiffnessMatrix(ctx,flow_maps,times=nothing; [quadrature_order, on_torus,on_cylinder, LL, UR, bdata, volume_preserving=true,flow_map_mode=0] )
 
 Calculate the matrix-representation of the bilinear form ``a(u,v) = 1/N \\sum_n^N a_1(I_hT_nu,I_hT_nv)`` where
 ``I_h`` is pointwise interpolation of the grid obtained by doing Delaunay triangulation on images of grid points from ctx
@@ -120,26 +120,22 @@ If `volume_preserving == false`, add a volume_correction term to ``a_1`` (See pa
 If `flow_map_mode==0`, apply flow map to nodal basis function coordinates.
 If `flow_map_mode==1`, apply flow map to nodal basis function index number (allows for precomputed trajectories).
 """
-function adaptiveTOCollocationStiffnessMatrix(
-        ctx::gridContext{2},
-        flow_maps::Function,
-        times=nothing
-        ;
-        quadrature_order=default_quadrature_order,
-        on_torus::Bool=false,
-        on_cylinder::Bool=false,
-        LL_future::AbstractVector{Float64}=ctx.spatialBounds[1],
-        UR_future::AbstractVector{Float64}=ctx.spatialBounds[2],
-        bdata::boundaryData=boundaryData(),
-        volume_preserving=true,
-        flow_map_mode=0
-        )
+function adaptiveTOCollocationStiffnessMatrix(ctx::GridContext{2}, flow_maps, times=nothing;
+                                        quadrature_order=default_quadrature_order,
+                                        on_torus::Bool=false,
+                                        on_cylinder::Bool=false,
+                                        LL_future::Tuple{<:Real,<:Real}=ctx.spatialBounds[1],
+                                        UR_future::Tuple{<:Real,<:Real}=ctx.spatialBounds[2],
+                                        bdata::BoundaryData=BoundaryData(),
+                                        volume_preserving=true,
+                                        flow_map_mode=0
+                                        )
     if !(on_torus || on_cylinder)  && length(bdata.periodic_dofs_from) != 0
         @warn "This function probably doesn't work for this case"
     end
 
 
-    if times==nothing
+    if times === nothing
         N = 1
     else
         N = length(times)
@@ -148,8 +144,8 @@ function adaptiveTOCollocationStiffnessMatrix(
     if on_torus || on_cylinder
         num_real_points = ctx.n - length(bdata.periodic_dofs_from)
     end
-    flow_map_images = zeros(Vec{2},(N,num_real_points))
-    if times == nothing
+    flow_map_images = zeros(Vec{2}, (N,num_real_points))
+    if times === nothing
         for i in 1:num_real_points
             if flow_map_mode == 0
                 flow_map_images[1,i] = Vec{2}(flow_maps(ctx.grid.nodes[i].x))
@@ -160,9 +156,9 @@ function adaptiveTOCollocationStiffnessMatrix(
     else
         for i in 1:num_real_points
             if flow_map_mode == 0
-                flow_map_images[:,i] = Vec{2}.(flow_maps(ctx.grid.nodes[i].x,times))
+                flow_map_images[:,i] = Vec{2}.(flow_maps(ctx.grid.nodes[i].x, times))
             else
-                flow_map_images[:,i] = Vec{2}.(flow_maps(i,times))
+                flow_map_images[:,i] = Vec{2}.(flow_maps(i, times))
             end
         end
     end
@@ -171,11 +167,13 @@ function adaptiveTOCollocationStiffnessMatrix(
     As = SparseMatrixCSC{Float64,Int64}[]
     for n in 1:N
         flow_map_t = j -> flow_map_images[n,j]
-        new_ctx,new_bdata,new_density_bcdofvals = adaptiveTOFutureGrid(ctx,flow_map_t;
-                                on_torus=on_torus,on_cylinder=on_cylinder,LL_future=LL_future,UR_future=UR_future,bdata=bdata,
-                                flow_map_mode=1
-                                )
-
+        new_ctx,new_bdata,new_density_bcdofvals = adaptiveTOFutureGrid(ctx, flow_map_t;
+                                                    on_torus=on_torus,
+                                                    on_cylinder=on_cylinder,
+                                                    LL_future=LL_future,
+                                                    UR_future=UR_future,
+                                                    bdata=bdata,
+                                                    flow_map_mode=1)
 
         translation_table = bcdof_to_node(new_ctx,new_bdata)
         #Assemble stiffness matrix
@@ -203,9 +201,9 @@ end
 
 #Reordering in the periodic case is slightly more tricky
 function bcdofNewToBcdofOld(
-        old_ctx::gridContext{dim},bdata::boundaryData,
-        new_ctx::gridContext{dim},new_bdata::boundaryData,K
-        ) where dim
+        old_ctx::GridContext{dim},bdata::BoundaryData,
+        new_ctx::GridContext{dim},new_bdata::BoundaryData,K
+        ) where {dim}
 
         I, J ,V = findnz(K)
 
@@ -221,13 +219,13 @@ function bcdofNewToBcdofOld(
         return sparse(I,J,V,old_pdof_n,old_pdof_n)
 end
 
-function node_to_bcdof(ctx::gridContext{dim},bdata::boundaryData) where dim
+function node_to_bcdof(ctx::GridContext{dim},bdata::BoundaryData) where {dim}
         n_nodes = ctx.n - length(bdata.periodic_dofs_from)
         bdata_table = BCTable(ctx,bdata)
         return bdata_table[ctx.node_to_dof]
 end
 
-function bcdof_to_node(ctx::gridContext{dim},bdata::boundaryData) where dim
+function bcdof_to_node(ctx::GridContext{dim},bdata::BoundaryData) where {dim}
         n_nodes = ctx.n - length(bdata.periodic_dofs_from)
         bdata_table = BCTable(ctx,bdata)
         result = zeros(Int,n_nodes)
@@ -241,20 +239,23 @@ end
 
 
 """
-    adaptiveTOFutureGrid(ctx, flow_map;[on_torus=false,bdata=nothing,LL,UR,quadrature_order,flow_map_mode=0])
+    adaptiveTOFutureGrid(ctx, flow_map; [on_torus=false, bdata=nothing, LL, UR, quadrature_order, flow_map_mode=0])
 
 Takes the (non-periodic) grid points from `ctx` (in bcdof order), applies `flow_map` to them,
-and (periodic) delaunay triangulates them and returns a P1-Delaunay `gridContext,bdata, volchange` tuple for that,
+and (periodic) delaunay triangulates them and returns a P1-Delaunay `GridContext,bdata, volchange` tuple for that,
 where `volchange` is a vector of relative volumes of the nodal basis functions.
 If `flow_map_mode==0` (default), apply `flow_map` to node coordinates. If `flow_map_mode==1`,
 apply `flow_map` to node index
 """
-function adaptiveTOFutureGrid(ctx::gridContext{dim},flow_map;
-        on_torus=false,on_cylinder=false,bdata=boundaryData(),LL_future=ctx.spatialBounds[1], UR_future=ctx.spatialBounds[2],
-        quadrature_order=default_quadrature_order,
-        flow_map_mode=0
-        ) where dim
-
+function adaptiveTOFutureGrid(ctx::GridContext{dim}, flow_map;
+                                on_torus=false,
+                                on_cylinder=false,
+                                bdata=BoundaryData(),
+                                LL_future=ctx.spatialBounds[1],
+                                UR_future=ctx.spatialBounds[2],
+                                quadrature_order=default_quadrature_order,
+                                flow_map_mode=0
+                                ) where {dim}
     if isEmptyBC(bdata) && (on_torus || on_cylinder)
         throw(AssertionError("Require bdata parameter if on_torus==true or on_cylinder==true"))
     end
@@ -262,35 +263,26 @@ function adaptiveTOFutureGrid(ctx::gridContext{dim},flow_map;
     #Push forward "original" nodes
 
     if flow_map_mode == 0
-        new_nodes_in_bcdof_order = [
-            Vec{2}(flow_map(ctx.grid.nodes[j].x))
-            for j in bcdof_to_node(ctx,bdata)
-                ]
+        new_nodes_in_bcdof_order = [Vec{2}(flow_map(ctx.grid.nodes[j].x)) for j in bcdof_to_node(ctx, bdata)]
     else
-        new_nodes_in_bcdof_order = [
-            Vec{2}(flow_map(j))
-            for j in bcdof_to_node(ctx,bdata)
-                ]
+        new_nodes_in_bcdof_order = [Vec{2}(flow_map(j)) for j in bcdof_to_node(ctx, bdata)]
     end
-    new_ctx, new_bdata = irregularDelaunayGrid(
-                            new_nodes_in_bcdof_order;
-                            on_torus=on_torus,on_cylinder=on_cylinder,LL=LL_future,UR=UR_future,
-                            quadrature_order=quadrature_order
-                            )
+    new_ctx, new_bdata = irregularDelaunayGrid(new_nodes_in_bcdof_order;
+                            on_torus=on_torus, on_cylinder=on_cylinder,
+                            LL=LL_future, UR=UR_future, quadrature_order=quadrature_order)
 
     #Do volume corrections
     #All values are in node order for new_ctx, which is the same as bcdof order for ctx2
     n_nodes = length(new_nodes_in_bcdof_order)
-    vols_new = sum(assembleMassMatrix(new_ctx,bdata=new_bdata),dims=1)[1,node_to_bcdof(new_ctx,new_bdata)[1:n_nodes]]
-    vols_old = sum(assembleMassMatrix(ctx,bdata=bdata),dims=1)[1,1:n_nodes]
+    vols_new = sum(assembleMassMatrix(new_ctx, bdata=new_bdata), dims=1)[1, node_to_bcdof(new_ctx, new_bdata)[1:n_nodes]]
+    vols_old = sum(assembleMassMatrix(ctx, bdata=bdata), dims=1)[1, 1:n_nodes]
 
-    return new_ctx,new_bdata, vols_new ./ vols_old
-
+    return new_ctx, new_bdata, vols_new ./ vols_old
 end
 
 
 """
-    adaptiveTOCollocation(ctx,flow_map; [on_torus=false,on_cylinder=false, bdata,LL,UR, volume_preserving=true])
+    adaptiveTOCollocation(ctx, flow_map; [on_torus=false, on_cylinder=false, bdata, LL, UR, volume_preserving=true])
 
 Calculate the represenation matrix for ``J_h I_h T`` where ``T`` is the Transfer-Operator
 for `flow_map` and ``J_h`` is the nodal interpolation operator for `ctx` and ``I_h`` is the
@@ -301,11 +293,12 @@ If `on_torus==true`, then everything is done with periodic boundary conditions.
 For `on_cylinder==true`, periodic only in x-direction.
 If `volume_preserving==false`, a correction is made for non-volume-preserving maps.
 """
-function adaptiveTOCollocation(ctx::gridContext{dim}, flow_map::Function;
-     on_torus::Bool=false,on_cylinder::Bool=false,  bdata=nothing, LL=[0.0,0.0],UR=[1.0,1.0],
-     volume_preserving=true,projection_method=:naTO
-     ) where dim
-
+function adaptiveTOCollocation(ctx::GridContext{dim}, flow_map;
+                                 on_torus::Bool=false,
+                                 on_cylinder::Bool=false,
+                                 bdata=nothing,
+                                 LL=(0.0,0.0), UR=(1.0,1.0),
+                                 volume_preserving=true, projection_method=:naTO) where {dim}
     if on_torus || on_cylinder
         if bdata === nothing
             throw(AssertionError("bdata == nothing"))
@@ -366,14 +359,14 @@ It should be noted that (perhaps counter-intuitively) `inverse_flow_map` should 
 grid described by `ctx_codomain` to that described by `ctx_domain`
 """
 function L2GalerkinTOFromInverse(
-                ctx_domain::gridContext{dim},
-                inverse_flow_map::Function,
-                ctx_codomain::gridContext{dim}=ctx_domain;
+                ctx_domain::GridContext{dim},
+                inverse_flow_map,
+                ctx_codomain::GridContext{dim}=ctx_domain;
                 ϵ::Float64=0.0, n_stencil_points::Int=10,
                 periodic_directions=(false,false),
-                bdata_domain=boundaryData(),
+                bdata_domain=BoundaryData(),
                 bdata_codomain=bdata_domain,
-                ) where dim
+                ) where {dim}
 
     #See http://blog.marmakoide.org/?p=1
     stencil::Vector{Vec{2,Float64}} = Vec{dim,Float64}[]
@@ -396,45 +389,45 @@ function L2GalerkinTOFromInverse(
     LL_domain::Vec{dim,Float64} = Vec{dim}(ctx_domain.spatialBounds[1])
     UR_domain::Vec{dim,Float64} = Vec{dim}(ctx_domain.spatialBounds[2])
 
-    cv::JuAFEM.CellScalarValues{dim} = JuAFEM.CellScalarValues(ctx_codomain.qr, ctx_codomain.ip,ctx_codomain.ip_geom)
-    nshapefuncs::Int = JuAFEM.getnbasefunctions(cv)         # number of basis functions
+    cv::JFM.CellScalarValues{dim} = JFM.CellScalarValues(ctx_codomain.qr, ctx_codomain.ip,ctx_codomain.ip_geom)
+    nshapefuncs::Int = JFM.getnbasefunctions(cv)         # number of basis functions
     dofs::Vector{Int} = zeros(nshapefuncs)
     index::Int = 1 #Counter to know the number of the current quadrature point
     DL2I = Vector{Int}()
     DL2J = Vector{Int}()
     DL2V = Vector{Float64}()
 
-    @inbounds for (cellnumber, cell) in enumerate(JuAFEM.CellIterator(ctx_codomain.dh))
-        JuAFEM.reinit!(cv,cell)
-        JuAFEM.celldofs!(dofs,ctx_codomain.dh,cellnumber)
+    @inbounds for (cellnumber, cell) in enumerate(JFM.CellIterator(ctx_codomain.dh))
+        JFM.reinit!(cv,cell)
+        JFM.celldofs!(dofs,ctx_codomain.dh,cellnumber)
         #Iterate over all quadrature points in the cell
-        for q in 1:JuAFEM.getnquadpoints(cv) # loop over quadrature points
-            dΩ::Float64 = JuAFEM.getdetJdV(cv,q)
-            TQ::Vec{dim,Float64} = Vec{dim}(inverse_flow_map(ctx_codomain.quadrature_points[index]))
+        for q in 1:JFM.getnquadpoints(cv) # loop over quadrature points
+            dΩ = JFM.getdetJdV(cv,q)
+            TQ = Vec{dim}(inverse_flow_map(ctx_codomain.quadrature_points[index]))
             for s in stencil
-                current_point::Vec{dim,Float64} = TQ + s
+                current_point = TQ + s
                 current_point = Vec{dim,Float64}( i ->
                     periodic_directions[i] ? LL_domain[i] + (mod(current_point[i] - LL_domain[i],UR_domain[i] - LL_domain[i])) : current_point[i]
                     )
                 try
-                    local_coords::Vec{dim,Float64}, nodes::Vector{Int},TQinvCellNumber = locatePoint(ctx_domain,current_point)
-                    if isa(ctx_domain.ip, JuAFEM.Lagrange)
+                    local_coords::Vec{dim,Float64}, nodes::Vector{Int}, TQinvCellNumber = locatePoint(ctx_domain,current_point)
+                    if ctx_domain.ip isa JFM.Lagrange
                         for (shape_fun_num,j) in enumerate(nodes)
-                                for i in 1:nshapefuncs
-                                    φ::Float64 = JuAFEM.shape_value(cv,q,i)
-                                    ψ::Float64 = JuAFEM.value(ctx_domain.ip,shape_fun_num,local_coords)
-                                    push!(DL2I, dofs[i])
-                                    push!(DL2J,ctx_domain.node_to_dof[j])
-                                    push!(DL2V, dΩ*φ*ψ*stencil_density)
-                                end
-                         end
+                            for i in 1:nshapefuncs
+                                φ = JFM.shape_value(cv,q,i)
+                                ψ = JFM.value(ctx_domain.ip,shape_fun_num,local_coords)
+                                push!(DL2I, dofs[i])
+                                push!(DL2J,ctx_domain.node_to_dof[j])
+                                push!(DL2V, dΩ*φ*ψ*stencil_density)
+                            end
+                        end
                     else
-                            push!(DL2I, ctx_codomain.cell_to_dof[cellnumber])
-                            push!(DL2J,ctx_domain.cell_to_dof[TQinvCellNumber])
-                            push!(DL2V, dΩ*stencil_density)
+                        push!(DL2I, ctx_codomain.cell_to_dof[cellnumber])
+                        push!(DL2J,ctx_domain.cell_to_dof[TQinvCellNumber])
+                        push!(DL2V, dΩ*stencil_density)
                     end
                 catch y
-                    if !isa(y,DomainError)
+                    if !isa(y, DomainError)
                         rethrow(y)
                     end
                     print("Got result $current_point outside of domain!")
@@ -444,10 +437,9 @@ function L2GalerkinTOFromInverse(
         end
     end
 
-    DL2::SparseMatrixCSC{Float64,Int64} = sparse(DL2I,DL2J, DL2V,ctx_codomain.n,ctx_domain.n)
-    return applyBCS(ctx_codomain,DL2,bdata_codomain;
-                    ctx_col=ctx_domain,bdata_col=bdata_domain,
-                    add_vals=true)
+    DL2 = sparse(DL2I, DL2J, DL2V, ctx_codomain.n, ctx_domain.n)
+    return applyBCS(ctx_codomain, DL2, bdata_codomain;
+                    ctx_col=ctx_domain, bdata_col=bdata_domain, add_vals=true)
 end
 
 """
@@ -458,73 +450,69 @@ Approximate the Transfer-Operator (for volume preserving maps) by calculating
 T_{i,j} = \\int φ_i ∘ F φ_j dx
 ```
 """
-function L2GalerkinTO(
-    ctx_domain::gridContext{dim},
-    flow_map::Function,
-    ctx_codomain::gridContext{dim}=ctx_domain;
-    bdata_domain=boundaryData(),
-    bdata_codomain=bdata_domain,
-    verbosity=1
-    ) where dim
-    DL2 = spzeros(ctx_codomain.n,ctx_domain.n)
-    cv::JuAFEM.CellScalarValues{dim} = JuAFEM.CellScalarValues(ctx_domain.qr,ctx_domain.ip, ctx_domain.ip_geom)
-    nbasefuncs = JuAFEM.getnbasefunctions(cv)         # number of basis functions
-    dofs::Vector{Int} = zeros(nbasefuncs)
-    index::Int = 1 #Counter to know the number of the current quadrature point
+function L2GalerkinTO(ctx_domain::GridContext{dim}, flow_map, ctx_codomain::GridContext{dim}=ctx_domain;
+                        bdata_domain=BoundaryData(),
+                        bdata_codomain=bdata_domain,
+                        verbosity=1) where {dim}
+    DL2 = spzeros(ctx_codomain.n, ctx_domain.n)
+    cv = JFM.CellScalarValues(ctx_domain.qr, ctx_domain.ip, ctx_domain.ip_geom)
+    nbasefuncs = JFM.getnbasefunctions(cv)         # number of basis functions
+    dofs = zeros(nbasefuncs)
+    index = 1 #Counter to know the number of the current quadrature point
     badcounter = 0
 
     #TODO: Make this more efficient
-    @inbounds for (cellnumber, cell) in enumerate(JuAFEM.CellIterator(ctx_domain.dh))
-        JuAFEM.reinit!(cv,cell)
-        JuAFEM.celldofs!(dofs,ctx_domain.dh,cellnumber)
+    @inbounds for (cellnumber, cell) in enumerate(JFM.CellIterator(ctx_domain.dh))
+        JFM.reinit!(cv,cell)
+        JFM.celldofs!(dofs,ctx_domain.dh,cellnumber)
         #Iterate over all quadrature points in the cell
-        for q in 1:JuAFEM.getnquadpoints(cv) # loop over quadrature points
-            dΩ::Float64 = JuAFEM.getdetJdV(cv,q)
-            TQ::Vec{2,Float64} = Vec{2}(flow_map(ctx_domain.quadrature_points[index]))
-            local_coordsTQ::Vec{2,Float64}, nodesTQ::Vector{Int},cellIndexTQ = try
+        for q in 1:JFM.getnquadpoints(cv) # loop over quadrature points
+            dΩ = JFM.getdetJdV(cv,q)
+            TQ = Vec{2}(flow_map(ctx_domain.quadrature_points[index]))
+            local_coordsTQ::Vec{2,Float64}, nodesTQ::Vector{Int}, cellIndexTQ = try
                     locatePoint(ctx_codomain,TQ)
             catch y
-                if !isa(y,DomainError)
+                if !isa(y, DomainError)
                     rethrow(y)
                 end
                 (verbosity >= 2) && @warn("Flow map gave result $TQ outside of domain!")
                 badcounter += 1
                 continue
             end
-            if isa(ctx_codomain.ip,JuAFEM.Lagrange)
-                    for (shape_fun_num,i) in enumerate(nodesTQ)
-                        ψ::Float64 = JuAFEM.value(ctx_codomain.ip,shape_fun_num,local_coordsTQ)
-                        indexi = ctx_domain.node_to_dof[i]
-                        for j in 1:nbasefuncs
-                            indexj::Int64 = 0
-                            if isa(ctx_domain.ip,JuAFEM.Lagrange)
-                                indexj=dofs[j]
-                                φ::Float64 = JuAFEM.shape_value(cv,q,j)
-                            else
-                                indexj=ctx_domain.cell_to_dof[cellnumber]
-                                φ = 1.0
-                            end
-                            DL2[indexi,indexj] += dΩ*φ*ψ
-                        end
-                    end
-            else
-                    indexi = ctx_codomain.cell_to_dof[cellIndexTQ]
-                    ψ = 1.0
+            if ctx_codomain.ip isa JFM.Lagrange
+                for (shape_fun_num, i) in enumerate(nodesTQ)
+                    ψ = JFM.value(ctx_codomain.ip,shape_fun_num,local_coordsTQ)
+                    indexi = ctx_domain.node_to_dof[i]
                     for j in 1:nbasefuncs
-                        indexj::Int64 = 0
-                        if isa(ctx_domain.ip,JuAFEM.Lagrange)
-                            indexj=dofs[j]
-                            φ::Float64 = JuAFEM.shape_value(cv,q,j)
+                        indexj = 0
+                        if ctx_domain.ip isa JFM.Lagrange
+                            indexj = dofs[j]
+                            φ = JFM.shape_value(cv,q,j)
                         else
-                            indexj=ctx_domain.cell_to_dof[cellnumber]
+                            indexj = ctx_domain.cell_to_dof[cellnumber]
                             φ = 1.0
                         end
-                        DL2[indexi, indexj] += dΩ*φ*ψ
+                        DL2[indexi,indexj] += dΩ*φ*ψ
                     end
+                end
+            else
+                indexi = ctx_codomain.cell_to_dof[cellIndexTQ]
+                ψ = 1.0
+                for j in 1:nbasefuncs
+                    indexj = 0
+                    if ctx_domain.ip isa JFM.Lagrange
+                        indexj = dofs[j]
+                        φ = JFM.shape_value(cv,q,j)
+                    else
+                        indexj = ctx_domain.cell_to_dof[cellnumber]
+                        φ = 1.0
+                    end
+                    DL2[indexi, indexj] += dΩ*φ*ψ
+                end
             end
         index += 1
         end
     end
     (verbosity >= 1 && badcounter > 0) && @warn "$badcounter results outside of domain"
-    return applyBCS(ctx_codomain,DL2,bdata_codomain; ctx_col=ctx_domain,bdata_col=bdata_domain)
+    return applyBCS(ctx_codomain, DL2, bdata_codomain; ctx_col=ctx_domain, bdata_col=bdata_domain)
 end

--- a/src/boundaryconditions.jl
+++ b/src/boundaryconditions.jl
@@ -32,12 +32,15 @@ mutable struct BoundaryData
         @assert issorted(periodic_dofs_from)
         return new(dbc_dofs, periodic_dofs_from, periodic_dofs_to)
     end
+    # TODO: should this be an outer constructor?
     function BoundaryData(ctx::GridContext, predicate, which_dbc=[])
         dbcs = getHomDBCS(ctx, which_dbc).dbc_dofs
         from, to = identifyPoints(ctx, predicate)
         return BoundaryData(dbcs, from, to)
     end
 end
+
+@deprecate boundaryData(args...; kwargs...) BoundaryData(args...; kwargs...)
 
 """
     getHomDBCS(ctx, which="all")

--- a/src/boundaryconditions.jl
+++ b/src/boundaryconditions.jl
@@ -4,26 +4,26 @@
 
 
 """
-    mutable struct boundaryData
+    mutable struct BoundaryData
 
 Represent (a combination of) homogeneous Dirichlet and periodic boundary conditions.
 
 ## Fields
-   * `dbc_dofs`: list of dofs that should have homogeneous Dirichlet boundary
-   conditions. Must be sorted.
+   * `dbc_dofs`: list of dofs that should have homogeneous Dirichlet boundary conditions.
+     Must be sorted.
    * `periodic_dofs_from` and `periodic_dofs_to` are both `Vector{Int}`. The
-   former *must* be strictly increasing, both must have the same length.
-   `periodic_dofs_from[i]` is identified with `periodic_dofs_to[i]`.
-   `periodic_dofs_from[i]` must be strictly larger than `periodic_dofs_to[i]`.
-   Multiple dofs can be identified with the same dof. If some dof is identified
-   with another dof and one of them is in `dbc_dofs`, both points *must* be in
-   `dbc_dofs`.
+     former *must* be strictly increasing, both must have the same length.
+     `periodic_dofs_from[i]` is identified with `periodic_dofs_to[i]`.
+     `periodic_dofs_from[i]` must be strictly larger than `periodic_dofs_to[i]`.
+     Multiple dofs can be identified with the same dof. If some dof is identified
+     with another dof and one of them is in `dbc_dofs`, both points *must* be in
+     `dbc_dofs`.
 """
-mutable struct boundaryData
+mutable struct BoundaryData
     dbc_dofs::Vector{Int}
     periodic_dofs_from::Vector{Int}
     periodic_dofs_to::Vector{Int}
-    function boundaryData(dbc_dofs::Vector{Int}=Vector{Int}(),
+    function BoundaryData(dbc_dofs::Vector{Int}=Vector{Int}(),
                             periodic_dofs_from::Vector{Int}=Vector{Int}(),
                             periodic_dofs_to::Vector{Int}=Vector{Int}()
                          )
@@ -32,20 +32,20 @@ mutable struct boundaryData
         @assert issorted(periodic_dofs_from)
         return new(dbc_dofs, periodic_dofs_from, periodic_dofs_to)
     end
-    function boundaryData(ctx::gridContext{dim}, predicate::T, which_dbc=[]) where {dim, T <: Union{Function,Distances.Metric}}
+    function BoundaryData(ctx::GridContext, predicate, which_dbc=[])
         dbcs = getHomDBCS(ctx, which_dbc).dbc_dofs
         from, to = identifyPoints(ctx, predicate)
-        return boundaryData(dbcs, from, to)
+        return BoundaryData(dbcs, from, to)
     end
 end
 
 """
-    getHomDBCS(ctx,which="all")
+    getHomDBCS(ctx, which="all")
 
-Return `boundaryData` object corresponding to homogeneous Dirichlet Boundary Conditions for a set of facesets.
-`which="all"` is shorthand for `["left","right","top","bottom"]`.
+Return `BoundaryData` object corresponding to homogeneous Dirichlet boundary conditions for
+a set of facesets. `which="all"` is shorthand for `["left", "right", "top", "bottom"]`.
 """
-function getHomDBCS(ctx::gridContext{dim}, which="all") where dim
+function getHomDBCS(ctx::GridContext{dim}, which="all") where {dim}
     dbcs = JFM.ConstraintHandler(ctx.dh)
     #TODO: See if newer version of JuAFEM export a "boundary" nodeset
     if which == "all"
@@ -61,30 +61,25 @@ function getHomDBCS(ctx::gridContext{dim}, which="all") where dim
                      JFM.getfaceset(ctx.grid, "top"),
                      JFM.getfaceset(ctx.grid, "bottom"),
                        ), (x, t) -> 0)
-       elseif dim == 3
-            dbc = JFM.Dirichlet(:T,
-                    union(JFM.getfaceset(ctx.grid, "left"),
-                     JFM.getfaceset(ctx.grid, "right"),
-                     JFM.getfaceset(ctx.grid, "top"),
-                     JFM.getfaceset(ctx.grid, "bottom"),
-                     JFM.getfaceset(ctx.grid, "front"),
-                     JFM.getfaceset(ctx.grid, "back"),
-                       ), (x, t) -> 0)
-       else
-           throw(AssertionError("dim ∉ [1,2,3]"))
-       end
-   elseif isempty(which)
-       return boundaryData(Vector{Int}())
-   else
-       dbc = JFM.Dirichlet(:T,
-               union([JFM.getfaceset(ctx.grid, str) for str in which]...),
-               (x, t) -> 0
-               )
-   end
+        elseif dim == 3
+            dbc = JFM.Dirichlet(:T, union(JFM.getfaceset(ctx.grid, "left"),
+                                             JFM.getfaceset(ctx.grid, "right"),
+                                             JFM.getfaceset(ctx.grid, "top"),
+                                             JFM.getfaceset(ctx.grid, "bottom"),
+                                             JFM.getfaceset(ctx.grid, "front"),
+                                             JFM.getfaceset(ctx.grid, "back")), (x, t) -> 0)
+        else
+            throw(AssertionError("dim ∉ [1,2,3]"))
+        end
+    elseif isempty(which)
+        return BoundaryData(Vector{Int}())
+    else
+        dbc = JFM.Dirichlet(:T, union([JFM.getfaceset(ctx.grid, str) for str in which]...), (x, t) -> 0)
+    end
     JFM.add!(dbcs, dbc)
     JFM.close!(dbcs)
     JFM.update!(dbcs, 0.0)
-    return boundaryData(dbcs.prescribed_dofs)
+    return BoundaryData(dbcs.prescribed_dofs)
 end
 
 """
@@ -94,21 +89,21 @@ Given a vector `u` in dof order with boundary conditions applied, return the
 corresponding `u` in dof order without the boundary conditions.
 """
 function undoBCS(ctx, u, bdata)
-        n = ctx.n
-        if length(bdata.dbc_dofs) == 0 && length(bdata.periodic_dofs_from) == 0
-            return copy(u)
+    n = ctx.n
+    if length(bdata.dbc_dofs) == 0 && length(bdata.periodic_dofs_from) == 0
+        return copy(u)
+    end
+    if n == length(u)
+        error("u is already of length n, no need for undoBCS")
+    end
+    correspondsTo = BCTable(ctx, bdata)
+    result = zeros(n)
+    for i in 1:n
+        if correspondsTo[i] != 0
+            result[i] = u[correspondsTo[i]]
         end
-        if n == length(u)
-            error("u is already of length n, no need for undoBCS")
-        end
-        correspondsTo = BCTable(ctx, bdata)
-        result = zeros(n)
-        for i in 1:n
-            if correspondsTo[i] != 0
-                result[i] = u[correspondsTo[i]]
-            end
-        end
-        return result
+    end
+    return result
 end
 
 """
@@ -116,18 +111,18 @@ end
 
 Return the coordinates of the node corresponding to the dof with index `dofindex`.
 """
-function getDofCoordinates(ctx::gridContext{dim}, dofindex::Int) where dim
+function getDofCoordinates(ctx::GridContext, dofindex::Int)
     return ctx.grid.nodes[ctx.dof_to_node[dofindex]].x
 end
 
 """
-    BCTable(ctx,bdata)
+    BCTable(ctx, bdata)
 
 Return a vector `res` so that `res[i] = j` means that dof `i` should be identified
 with bcdof `j` if `j != 0`. If `j = 0` dof `i` is part of a homogeneous Dirichlet
 boundary condition.
 """
-function BCTable(ctx::gridContext{dim},bdata::boundaryData) where dim
+function BCTable(ctx::GridContext, bdata::BoundaryData)
     dbcs_prescribed_dofs = bdata.dbc_dofs
     periodic_dofs_from   = bdata.periodic_dofs_from
     periodic_dofs_to     = bdata.periodic_dofs_to
@@ -187,9 +182,7 @@ end
 Get the number of dofs that are left after the boundary conditions in `bdata`
 have been applied.
 """
-function nBCDofs(ctx::gridContext{dim}, bdata::boundaryData) where dim
-    return length(unique(BCTable(ctx, bdata)))
-end
+nBCDofs(ctx::GridContext, bdata::BoundaryData) = length(unique(BCTable(ctx, bdata)))
 
 """
     doBCS(ctx, u, bdata)
@@ -197,7 +190,7 @@ end
 Take a vector `u` in dof order and throw away unneccessary dofs.
 This is a left-inverse to undoBCS.
 """
-function doBCS(ctx, u::AbstractVector{T}, bdata) where T
+function doBCS(ctx, u::AbstractVector{T}, bdata) where {T}
     @assert length(u) == ctx.n
     #Is = findall(i -> ∉(i,bdata.dbc_dofs) && ∉(i,bdata.periodic_dofs_from), 1:ctx.n)
     #return u[Is]
@@ -223,8 +216,8 @@ matrix `K`. Only applies boundary conditions accross columns (rows) if
 then values in rows that should be cominbed are added. Otherwise, one of the rows
 is discarded and the values of the other are used.
 """
-function applyBCS(ctx_row::gridContext{dim}, K, bdata_row;
-                    ctx_col::gridContext{dim}=ctx_row, bdata_col=bdata_row,
+function applyBCS(ctx_row::GridContext{dim}, K, bdata_row;
+                    ctx_col::GridContext{dim}=ctx_row, bdata_col=bdata_row,
                     add_vals=true) where {dim}
 
     n, m = size(K)
@@ -314,7 +307,7 @@ function applyBCS(ctx_row::gridContext{dim}, K, bdata_row;
     end
 end
 
-function identifyPoints(ctx::gridContext{dim}, predicate::Function) where dim
+function identifyPoints(ctx::GridContext, predicate)
     boundary_dofs = getHomDBCS(ctx).dbc_dofs
     identify_from = Int[]
     identify_to = Int[]
@@ -331,7 +324,7 @@ function identifyPoints(ctx::gridContext{dim}, predicate::Function) where dim
 end
 
 
-function identifyPoints(ctx::gridContext{dim}, predicate::Distances.Metric) where dim
+function identifyPoints(ctx::GridContext{dim}, predicate::Distances.Metric) where {dim}
 
     identify_from = Int[]
     identify_to = Int[]
@@ -355,19 +348,17 @@ function identifyPoints(ctx::gridContext{dim}, predicate::Distances.Metric) wher
     return identify_from, identify_to
 end
 
-function isEmptyBC(bdata::boundaryData)
-    return isempty(bdata.dbc_dofs) && isempty(bdata.periodic_dofs_from)
-end
+isEmptyBC(bdata::BoundaryData) = all(isempty, (bdata.dbc_dofs, bdata.periodic_dofs_from))
 
-function get_full_dofvals(ctx,dof_vals; bdata=nothing)
+function get_full_dofvals(ctx, dof_vals; bdata=nothing)
     if (bdata==nothing) && (ctx.n != length(dof_vals))
         dbcs = getHomDBCS(ctx)
         if length(dbcs.dbc_dofs) + length(dof_vals) != ctx.n
             error("Input u has wrong length")
         end
-        dof_values = undoBCS(ctx,dof_vals,dbcs)
+        dof_values = undoBCS(ctx, dof_vals, dbcs)
     elseif (bdata != nothing)
-        dof_values = undoBCS(ctx,dof_vals,bdata)
+        dof_values = undoBCS(ctx, dof_vals, bdata)
     else
         dof_values = dof_vals
     end

--- a/src/ellipticLCS.jl
+++ b/src/ellipticLCS.jl
@@ -558,7 +558,7 @@ function compute_returning_orbit(vf, seed::SVector{2,T}, save::Bool=false,
         end
         return (sol.u, retcode)
     catch e
-        if isa(e, BoundsError)
+        if e isa BoundsError
     	    return (SArray{Tuple{2},T,1,2}[@SVector [NaN,NaN] ], 2)
         end
         rethrow(e)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -70,7 +70,6 @@ export
 	regularTetrahedralGrid,
 	regularP2TetrahedralGrid,
 	regularGrid,
-	randomDelaunayGrid,
 	evaluate_function_from_dofvals,
 	evaluate_function_from_node_or_cellvals,
 	evaluate_function_from_node_or_cellvals_multiple,

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -56,7 +56,8 @@ export
 	#gridfunctions.jl
 	regular1dGridTypes,
 	regular2dGridTypes,
-	regular1dGrid,
+	regular1dPCGrid,
+	regular1dP1Grid,
 	regular1dP2Grid,
 	regularTriangularGrid,
 	regularDelaunayGrid,
@@ -80,7 +81,7 @@ export
 	doBCS,
 	applyBCS,
 	getHomDBCS,
-	boundaryData,
+	BoundaryData,
 	nBCDofs,
 	getDofCoordinates,
 	getCellMidpoint,

--- a/src/gridfunctions.jl
+++ b/src/gridfunctions.jl
@@ -221,7 +221,7 @@ function regular1dPCGrid(numnodes::Tuple{Int}, left::Real=0.0, right::Real=1.0;
 end
 
 """
-    regular1dGrid(numnodes, left=0.0, right=1.0; [quadrature_order])
+    regular1dP1Grid(numnodes, left=0.0, right=1.0; [quadrature_order])
 
 Create a regular grid with `numnodes` nodes on the interval `[left, right]` in 1d, with
 P1-Lagrange basis functions.
@@ -239,8 +239,8 @@ end
 """
     regular1dP2Grid(numnodes, left=0.0, right=1.0; [quadrature_order])
 
-Create a regular grid with `numnodes` non-interior nodes on the interval `[left,right]`.
-Uses P2-Lagrange elements.
+Create a regular grid with `numnodes` non-interior nodes on the interval `[left, right]`,
+with P2-Lagrange elements.
 """
 function regular1dP2Grid(numnodes::Int, args...; kwargs...)
     return regular1dP2Grid((numnodes,), args...; kwargs...)

--- a/src/gridfunctions.jl
+++ b/src/gridfunctions.jl
@@ -9,42 +9,41 @@
 const default_quadrature_order = 5
 const default_quadrature_order3D = 2
 
-
 """
-    struct gridContext<dim>
+    mutable struct GridContext
 
 Stores everything needed as "context" to be able to work on a FEM grid based on the `JuAFEM` package.
 Adds a point-locator API which facilitates plotting functions defined on the grid within Julia.
 
 # Fields
-- `grid::JuAFEM.Grid`, `ip::JuAFEM.Interpolation`,`ip_geom::JuAFEM.Interpolation`, `qr::JuAFEM.QuadratureRule` - See the `JuAFEM` package
-- `loc::CellLocator` object used for point-location on the grid.
+- `grid::JuAFEM.Grid`, `ip::JuAFEM.Interpolation`, `ip_geom::JuAFEM.Interpolation`, `qr::JuAFEM.QuadratureRule` - see the [`JuAFEM`](https://github.com/KristofferC/JuAFEM.jl) package.
+- `loc::PointLocator`: object used for point location on the grid.
 
-- `node_to_dof::Vector{Int}`  lookup table for dof index of a node (for Lagrange elements)
-- `dof_to_node::Vector{Int}`  inverse of node_to_dof
+- `node_to_dof::Vector{Int}`: lookup table for dof index of a node (for Lagrange elements)
+- `dof_to_node::Vector{Int}`: inverse of node_to_dof
 
-- `cell_to_dof::Vector{Int}`  lookup table for dof index of a cell (for piecewise constant elements)
-- `dof_to_cell::Vector{Int}`  inverse of cell_to_dof
+- `cell_to_dof::Vector{Int}`: lookup table for dof index of a cell (for piecewise constant elements)
+- `dof_to_cell::Vector{Int}`: inverse of cell_to_dof
 
-- `num_nodes::Int` number of nodes on the grid
-- `num_cells::Int` number of elements (e.g. triangles,quadrilaterals, ...) on the grid
-- `n` number of degrees of freedom (== `num_nodes` for Lagrange Elements, and == `num_cells` for piecewise constant elements)
+- `num_nodes`: number of nodes on the grid
+- `num_cells`: number of elements (e.g. triangles,quadrilaterals, ...) on the grid
+- `n`: number of degrees of freedom (== `num_nodes` for Lagrange Elements, and == `num_cells` for piecewise constant elements)
 
-- `quadrature_points::Vector{Vec{dim,Float64}}` All quadrature points on the grid, in a fixed order.
-- `mass_weights::Vector{Float64}` Weighting for stiffness/mass matrices
+- `quadrature_points::Vector{Vec{dim,Float64}}`: lists of all quadrature points on the grid, in a specific order.
+- `mass_weights::Vector{Float64}`: weighting for stiffness/mass matrices.
 
-- `spatialBounds` If available, the corners of a bounding box of a domain. For regular grids, the bounds are tight.
-- `numberOfPointsInEachDirection` For regular grids, how many (non-interior) nodes make up the regular grid.
-- `gridType` A string describing what kind of grid this is (e.g. "regular triangular grid")
-- `no_precompute=false`. Whether or not to precompute things like quadrature points. Only enable this if you know what you are doing.
+- `spatialBounds`: if available, the corners of a bounding box of a domain. For regular grids, the bounds are tight.
+- `numberOfPointsInEachDirection`: for regular grids, how many (non-interior) nodes make up the regular grid.
+- `gridType`: a string describing what kind of grid this is (e.g. "regular triangular grid")
+- `no_precompute=false`: whether to precompute objects like quadrature points. Only enable this if you know what you are doing.
 """
-mutable struct gridContext{dim} <: abstractGridContext{dim} #TODO: Currently set as mutable, is this sensible?
-    grid::JFM.Grid
-    ip::JFM.Interpolation
-    ip_geom::JFM.Interpolation
-    dh::JFM.DofHandler
-    qr::JFM.QuadratureRule
-    loc::pointLocator
+mutable struct GridContext{dim,G<:JFM.Grid,ITP<:JFM.Interpolation,ITPG<:JFM.Interpolation,DH<:JFM.DofHandler,QR<:JFM.QuadratureRule,PL<:PointLocator} <: AbstractGridContext{dim} #TODO: Currently set as mutable, is this sensible?
+    grid::G
+    ip::ITP
+    ip_geom::ITPG
+    dh::DH
+    qr::QR
+    loc::PL
 
     ##The following two fields only make sense for Lagrange-elements##
     node_to_dof::Vector{Int} #node_to_dof[nodeid] contains the index of the corresponding dof
@@ -63,32 +62,32 @@ mutable struct gridContext{dim} <: abstractGridContext{dim} #TODO: Currently set
     mass_weights::Vector{Float64}
 
     ##The following two fields are only well-defined for regular rectangular grids
-    spatialBounds::Vector{AbstractVector} #This is {LL,UR} for regular grids
+    spatialBounds::NTuple{2,NTuple{dim,Float64}} #This is {LL,UR} for regular grids
     #This is the number of (non-interior) nodes in each direction (not points)
     numberOfPointsInEachDirection::Vector{Int}
 
     gridType::String
 
-    function gridContext{dim}(
+    function GridContext{dim}(
                 grid::JFM.Grid,
                 ip::JFM.Interpolation,
                 ip_geom::JFM.Interpolation,
                 dh::JFM.DofHandler,
                 qr::JFM.QuadratureRule,
-                loc::pointLocator;
+                loc::PointLocator;
                 no_precompute=false
             ) where {dim}
 
-        x =new{dim}(grid, ip,ip_geom, dh, qr, loc)
+        x = new{dim,typeof(grid),typeof(ip),typeof(ip_geom),typeof(dh),typeof(qr),typeof(loc)}(grid, ip, ip_geom, dh, qr, loc)
         x.num_nodes = JFM.getnnodes(dh.grid)
         x.num_cells = JFM.getncells(dh.grid)
         x.n = JFM.ndofs(dh)
 
         #TODO: Measure if the sorting below is expensive
-        if isa(ip,JFM.Lagrange)
+        if ip isa JFM.Lagrange
             x.node_to_dof = nodeToDHTable(x)
             x.dof_to_node = sortperm(x.node_to_dof)
-        elseif isa(ip,JFM.PiecewiseConstant)
+        elseif ip isa JFM.PiecewiseConstant
             x.cell_to_dof = cellToDHTable(x)
             x.dof_to_cell = sortperm(x.cell_to_dof)
         else
@@ -104,10 +103,9 @@ mutable struct gridContext{dim} <: abstractGridContext{dim} #TODO: Currently set
     end
 end
 
-
 #Based on JuAFEM's WriteVTK.vtk_point_data
-function nodeToDHTable(ctx::abstractGridContext{dim}) where {dim}
-    dh::JFM.DofHandler = ctx.dh
+function nodeToDHTable(ctx::AbstractGridContext{dim}) where {dim}
+    dh = ctx.dh
     n = ctx.n
     res = Vector{Int}(undef,n)
     for cell in JFM.CellIterator(dh)
@@ -115,15 +113,15 @@ function nodeToDHTable(ctx::abstractGridContext{dim}) where {dim}
         ctr = 1
         offset = JFM.field_offset(dh, dh.field_names[1])
         for node in JFM.getnodes(cell)
-               res[node] = _celldofs[ctr + offset]
-               ctr += 1
+            res[node] = _celldofs[ctr + offset]
+            ctr += 1
         end
     end
     return res
 end
 
-function cellToDHTable(ctx::abstractGridContext{dim}) where {dim}
-    dh::JFM.DofHandler = ctx.dh
+function cellToDHTable(ctx::AbstractGridContext{dim}) where {dim}
+    dh = ctx.dh
     n = ctx.n
     res = Vector{Int}(undef,n)
     for (cellindex,cell) in enumerate(JFM.CellIterator(dh))
@@ -138,30 +136,29 @@ function cellToDHTable(ctx::abstractGridContext{dim}) where {dim}
 end
 #=
 """
-    gridContext{1}(JFM.Line, [numnodes, LL, UR; ip,quadrature_order,ip])
+    GridContext{1}(JFM.Line, [numnodes, LL, UR; ip,quadrature_order,ip])
 
 Constructor for a 1d regular mesh with `numnodes[1]` node on the interval `[LL[1],UR[1]]`.
 The default for `ip` is P1-Lagrange elements, but piecewise-constant elements can also be used.
 """
 =#
-function gridContext{1}(::Type{JFM.Line},
-                         numnodes::Tuple{Int}=( 25), LL::AbstractVector=[0.0], UR::AbstractVector=[1.0];
+function GridContext{1}(::Type{JFM.Line},
+                         numnodes::Tuple{Int}=(25,), LL::Tuple{<:Real}=(0.0,), UR::Tuple{<:Real}=(1.0,);
                          quadrature_order::Int=default_quadrature_order,
-                         ip=JFM.Lagrange{1,JFM.RefCube,1}(),kwargs...
-                         )
+                         ip=JFM.Lagrange{1,JFM.RefCube,1}(), kwargs...)
     # The -1 below is needed because JuAFEM internally then goes on to increment it
     grid = JFM.generate_grid(JFM.Line, (numnodes[1]-1,), Vec{1}(LL), Vec{1}(UR))
-    loc = regular1dGridLocator{JFM.Line}(numnodes[1], Vec{1}(LL), Vec{1}(UR))
+    loc = Regular1dGridLocator{JFM.Line}(numnodes[1], Vec{1}(LL), Vec{1}(UR))
 
     dh = JFM.DofHandler(grid)
-    push!(dh, :T, 1,ip) #The :T is just a generic name for the scalar field
+    push!(dh, :T, 1, ip) #The :T is just a generic name for the scalar field
     JFM.close!(dh)
 
     qr = JFM.QuadratureRule{1, JFM.RefCube}(quadrature_order)
-    result = gridContext{1}(grid, ip,JFM.Lagrange{1,JFM.RefCube,1}(), dh, qr, loc; kwargs...)
-    result.spatialBounds = [LL,UR]
+    result = GridContext{1}(grid, ip,JFM.Lagrange{1,JFM.RefCube,1}(), dh, qr, loc; kwargs...)
+    result.spatialBounds = (LL, UR)
     result.numberOfPointsInEachDirection = [numnodes[1]]
-    if isa(ip, JFM.Lagrange)
+    if ip isa JFM.Lagrange
         result.gridType = "regular P1 1d grid"
     else
         result.gridType = "regular PC 1d grid"
@@ -172,25 +169,25 @@ end
 
 #=
 """
-    gridContext{1}(JuAFEM.QuadraticLine, numnodes, LL, UR, quadrature_order)
+    GridContext{1}(JuAFEM.QuadraticLine, numnodes, LL, UR, quadrature_order)
 """
 =#
-function gridContext{1}(::Type{JFM.QuadraticLine},
-                         numnodes::Tuple{Int}=( 25),
-                         LL::AbstractVector=[0.0],
-                         UR::AbstractVector=[1.0];
+function GridContext{1}(::Type{JFM.QuadraticLine},
+                         numnodes::Tuple{Int}=(25,),
+                         LL::Tuple{<:Real}=(0.0,),
+                         UR::Tuple{<:Real}=(1.0,);
                          quadrature_order::Int=default_quadrature_order,
                          ip=JFM.Lagrange{1,JFM.RefCube,2}(), kwargs...
                          )
     # The -1 below is needed because JuAFEM internally then goes on to increment it
     grid = JFM.generate_grid(JFM.QuadraticLine, (numnodes[1]-1,), Vec{1}(LL), Vec{1}(UR))
-    loc = regular1dGridLocator{JFM.QuadraticLine}(numnodes[1], Vec{1}(LL), Vec{1}(UR))
+    loc = Regular1dGridLocator{JFM.QuadraticLine}(numnodes[1], Vec{1}(LL), Vec{1}(UR))
     dh = JFM.DofHandler(grid)
     qr = JFM.QuadratureRule{1, JFM.RefCube}(quadrature_order)
     push!(dh, :T, 1) #The :T is just a generic name for the scalar field
     JFM.close!(dh)
-    result = gridContext{1}(grid, ip,JFM.Lagrange{1,JFM.RefCube,2}(), dh, qr, loc;kwargs...)
-    result.spatialBounds = [LL,UR]
+    result = GridContext{1}(grid, ip, JFM.Lagrange{1,JFM.RefCube,2}(), dh, qr, loc; kwargs...)
+    result.spatialBounds = (LL, UR)
     result.numberOfPointsInEachDirection = [numnodes[1]]
     if !isa(ip, JFM.Lagrange)
         @warn("Using non-Lagrange shape functions may or may not work on this mesh")
@@ -205,56 +202,54 @@ const regular1dGridTypes = [
     "regular P2 1d grid"
     ]
 
-
 """
-    regular1dGrid(numnodes,left=0.0,right=1.0; [quadrature_order, PC=false])
+    regular1dPCGrid(numnodes, left=0.0, right=1.0; [quadrature_order])
 
-Create a regular grid with `numnodes` nodes on the interval `[left,right]` in 1d.
-If `PC==false`, uses P1-Lagrange basis functions. If `PC=true`, uses piecewise-constant
-basis functions.
+Create a regular grid with `numnodes` nodes on the interval `[left, right]` in 1d, with
+piecewise-constant basis functions.
 """
-function regular1dGrid(
-    numnodes::Int,left=0.0,right=1.0;
-    quadrature_order::Int=default_quadrature_order,
-    PC=false, kwargs...
-    )
-    if !PC
-        result = gridContext{1}(JFM.Line,(numnodes,), [left],[right]; quadrature_order=quadrature_order,kwargs...)
-    else
-        result = gridContext{1}(JFM.Line,(numnodes,),
-        [left],[right];
-        quadrature_order=quadrature_order,
-        ip=JFM.PiecewiseConstant{1,JFM.RefCube,1}(),kwargs...
-        )
-    end
-    return result, boundaryData()
+function regular1dPCGrid(numnodes::Int, args...; kwargs...)
+    return regular1dPCGrid((numnodes,), args...; kwargs...)
 end
-
-function regular1dGrid(numnodes::Tuple{Int},args...;kwargs...)
-    return regular1dGrid(numnodes[1],args...;kwargs...)
+function regular1dPCGrid(numnodes::Tuple{Int}, left::Real=0.0, right::Real=1.0;
+                    quadrature_order::Int=default_quadrature_order, kwargs...)
+    result = GridContext{1}(JFM.Line, (numnodes,), (left,), (right,);
+                            quadrature_order=quadrature_order,
+                            ip=JFM.PiecewiseConstant{1,JFM.RefCube,1}(),
+                            kwargs...)
+    return result, BoundaryData()
 end
 
 """
-    regular1dP2Grid(numnodes, [left,right; quadrature_order])
+    regular1dGrid(numnodes, left=0.0, right=1.0; [quadrature_order])
+
+Create a regular grid with `numnodes` nodes on the interval `[left, right]` in 1d, with
+P1-Lagrange basis functions.
+"""
+function regular1dP1Grid(numnodes::Int, args...; kwargs...)
+    return regular1dP1Grid((numnodes,), args...; kwargs...)
+end
+function regular1dP1Grid(numnodes::Tuple{Int}, left::Real=0.0, right::Real=1.0;
+                    quadrature_order::Int=default_quadrature_order, kwargs...)
+    result = GridContext{1}(JFM.Line, numnodes, (left,), (right,);
+                            quadrature_order=quadrature_order, kwargs...)
+    return result, BoundaryData()
+end
+
+"""
+    regular1dP2Grid(numnodes, left=0.0, right=1.0; [quadrature_order])
 
 Create a regular grid with `numnodes` non-interior nodes on the interval `[left,right]`.
 Uses P2-Lagrange elements.
 """
-function regular1dP2Grid(
-    numnodes::Int,left=0.0,right=1.0;
-    quadrature_order::Int=default_quadrature_order,kwargs...
-    )
-    result = gridContext{1}(
-        JFM.QuadraticLine,
-        (numnodes,),
-         [left],[right];
-         quadrature_order=quadrature_order, kwargs...
-         )
-    return result, boundaryData()
+function regular1dP2Grid(numnodes::Int, args...; kwargs...)
+    return regular1dP2Grid((numnodes,), args...; kwargs...)
 end
-
-function regular1dP2Grid(numnodes::Tuple{Int},args...;kwargs...)
-    return regular1dP2Grid(numnodes[1],args...;kwargs...)
+function regular1dP2Grid(numnodes::Tuple{Int}, left=0.0, right=1.0;
+                            quadrature_order::Int=default_quadrature_order, kwargs...)
+    result = GridContext{1}(JFM.QuadraticLine, numnodes, (left,), (right,);
+                                quadrature_order=quadrature_order, kwargs...)
+    return result, BoundaryData()
 end
 
 const regular2dGridTypes = [
@@ -269,25 +264,26 @@ const regular2dGridTypes = [
                     "regular P2 quadrilateral grid"
                     ]
 
+# TODO: unclear what this function is good for... completely type unstable!
 """
-    regular2dGrid(gridType, numnodes, LL=[0.0,0.0],UR=[1.0,1.0];quadrature_order=default_quadrature_order)
+    regular2dGrid(gridType, numnodes, LL=(0.0,0.0), UR=(1.0,1.0); quadrature_order=default_quadrature_order)
 
-Constructs a regular grid. `gridType` should be from `CoherentStructures.regular2dGridTypes`
+Constructs a regular grid. `gridType` should be from `CoherentStructures.regular2dGridTypes`.
 """
 function regular2dGrid(
             gridType::String,
             numnodes::Tuple{Int,Int},
-            LL::AbstractVector=[0.0,0.0],
-            UR::AbstractVector=[1.0,1.0];
+            LL::Tuple{<:Real,<:Real}=(0.0,0.0),
+            UR::Tuple{<:Real,<:Real}=(1.0,1.0);
             kwargs...
         )
 
     if gridType == "regular PC triangular grid"
-        return regularTriangularGrid(numnodes, LL, UR;PC=true, kwargs...)
+        return regularTriangularGrid(numnodes, LL, UR; PC=true, kwargs...)
     elseif gridType == "regular P1 triangular grid"
         return regularTriangularGrid(numnodes, LL, UR; kwargs...)
     elseif gridType == "regular PC Delaunay grid"
-        return regularDelaunayGrid(numnodes, LL, UR;PC=true, kwargs...)
+        return regularDelaunayGrid(numnodes, LL, UR; PC=true, kwargs...)
     elseif gridType == "regular P1 Delaunay grid"
         return regularDelaunayGrid(numnodes, LL, UR; kwargs...)
     elseif gridType == "regular P2 triangular grid"
@@ -295,7 +291,7 @@ function regular2dGrid(
     elseif gridType == "regular P2 Delaunay grid"
         return regularP2DelaunayGrid(numnodes, LL, UR; kwargs...)
     elseif gridType == "regular PC quadrilateral grid"
-        return regularQuadrilateralGrid(numnodes, LL, UR;PC=true, kwargs...)
+        return regularQuadrilateralGrid(numnodes, LL, UR; PC=true, kwargs...)
     elseif gridType == "regular P1 quadrilateral grid"
         return regularQuadrilateralGrid(numnodes, LL, UR; kwargs...)
     elseif gridType == "regular P2 quadrilateral grid"
@@ -308,7 +304,7 @@ end
 
 #= #TODO 1.0
 """
-    gridContext{2}(JuAFEM.Triangle, node_list; [on_torus=false,on_cylinder=false,LL,UR,quadrature_order=default_quadrature_order,ip])
+    GridContext{2}(JuAFEM.Triangle, node_list; [on_torus=false,on_cylinder=false,LL,UR,quadrature_order=default_quadrature_order,ip])
 
 Create a P1-Lagrange grid based on Delaunay Triangulation.
 If `on_torus==true`, triangulates on a periodic domain (in both directions)
@@ -319,7 +315,7 @@ i
 Uses `DelaunayVoronoi.jl` internally.
 """
 =#
-function gridContext{2}(
+function GridContext{2}(
             ::Type{JFM.Triangle},
             node_list::Vector{Vec{2,Float64}};
             quadrature_order::Int=default_quadrature_order,
@@ -330,36 +326,34 @@ function gridContext{2}(
             ip=JFM.Lagrange{2,JFM.RefTetrahedron,1}(),kwargs...
             )
     if on_torus || on_cylinder
-        @assert !( LL == nothing || UR == nothing)
+        @assert !(LL === nothing || UR === nothing)
     end
-    grid, loc = JFM.generate_grid(
-            JFM.Triangle, node_list;
-            on_torus=on_torus,on_cylinder=on_cylinder,LL=LL,UR=UR
-            )
+    grid, loc = JFM.generate_grid(JFM.Triangle, node_list;
+                    on_torus=on_torus, on_cylinder=on_cylinder, LL=LL, UR=UR)
     dh = JFM.DofHandler(grid)
     qr = JFM.QuadratureRule{2, JFM.RefTetrahedron}(quadrature_order)
-    push!(dh, :T, 1,ip) #The :T is just a generic name for the scalar field
+    push!(dh, :T, 1, ip) #The :T is just a generic name for the scalar field
     JFM.close!(dh)
-    result =  gridContext{2}(grid, ip,JFM.Lagrange{2,JFM.RefTetrahedron,1}(), dh, qr, loc;kwargs...)
-    if isa(ip, JFM.Lagrange)
+    result =  GridContext{2}(grid, ip, JFM.Lagrange{2,JFM.RefTetrahedron,1}(), dh, qr, loc; kwargs...)
+    if ip isa JFM.Lagrange
         result.gridType = "irregular P1 Delaunay grid"
     else
         result.gridType = "irregular PC Delaunay grid"
     end
-    if LL == nothing
-        LL = [minimum([x[i] for x in node_list]) for i in 1:2]
+    if LL === nothing
+        LL = map(i -> minimum([x[i] for x in node_list]), (1, 2))
     end
-    if UR == nothing
-        UR = [maximum([x[i] for x in node_list]) for i in 1:2]
+    if UR === nothing
+        UR = map(i -> maximum([x[i] for x in node_list]), (1, 2))
     end
-    result.spatialBounds = [LL,UR]
+    result.spatialBounds = (LL, UR)
     return result
 end
 
 """
-    irregularDelaunayGrid(nodes_in; [on_torus=false,on_cylinder=false,LL,UR,PC=false,...])
+    irregularDelaunayGrid(nodes_in; [on_torus=false, on_cylinder=false, LL, UR, PC=false, ...])
 
-Triangulate the nodes `nodes_in` and return a `gridContext` and `bdata` for them.
+Triangulate the nodes `nodes_in` and return a `GridContext` and `bdata` for them.
 If `on_torus==true`, the triangulation is done on a torus.
 If `PC==true`, return a mesh with piecewise constant shape-functions, else P1 Lagrange.
 """
@@ -373,32 +367,33 @@ function irregularDelaunayGrid(nodes_in::Vector{Vec{2,Float64}};
     else
         ip = JFM.PiecewiseConstant{2,JFM.RefTetrahedron,1}()
     end
-    ctx = gridContext{2}(JFM.Triangle, nodes_in;
+    ctx = GridContext{2}(JFM.Triangle, nodes_in;
             on_torus=on_torus, on_cylinder=on_cylinder, LL=LL, UR=UR, ip=ip, kwargs...)
     if on_torus
-        bdata = boundaryData(ctx, Dists.PeriodicEuclidean(UR .- LL))
+        bdata = BoundaryData(ctx, Dists.PeriodicEuclidean([UR[1] - LL[1], UR[2] - LL[2]]))
     elseif on_cylinder
-        bdata = boundaryData(ctx, Dists.PeriodicEuclidean([UR[1] - LL[1], Inf]))
+        bdata = BoundaryData(ctx, Dists.PeriodicEuclidean([UR[1] - LL[1], Inf]))
     else
-        bdata = boundaryData()
+        bdata = BoundaryData()
     end
     return ctx, bdata
 end
 
 """
     randomDelaunayGrid(npoints; LL, UR,...)
+
 Create a delaunay grid in 2d from `npoints` random points on the box with lower
 left corner `LL` and upper right corner `UR`.
 Extra keyword arguments are passed down to `irregularDelaunayGrid`.
 """
 function randomDelaunayGrid(npoints::Int;
-                            LL=[0.0,0.0], UR=[1.0,1.0], kwargs...)
+                            LL::Tuple{<:Real,<:Real}=(0.0,0.0), UR::Tuple{<:Real,<:Real}=(1.0,1.0), kwargs...)
     nodes_in::Vector{Vec{2,Float64}} = Vec{2}.(zip(rand(npoints).*(UR[1]-LL[1]) .+ LL[1],rand(npoints).*(UR[2]-LL[2]) .+ LL[2]))
-    return irregularDelaunayGrid(nodes_in; LL=LL,UR=UR,kwargs...)
+    return irregularDelaunayGrid(nodes_in; LL=LL, UR=UR, kwargs...)
 end
 
 """
-    regularDelaunayGrid(numnodes=(25,25), LL, UR; [quadrature_order,on_torus=false,on_cylinder=false, nudge_epsilon=1e-5,PC=false])
+    regularDelaunayGrid(numnodes=(25,25), LL, UR; [quadrature_order, on_torus=false, on_cylinder=false, nudge_epsilon=1e-5, PC=false])
 
 Create a regular grid on a square with lower left corner `LL` and upper-right corner `UR`.
 Internally uses Delauny Triangulation.
@@ -410,15 +405,15 @@ If `PC==true`, returns a piecewise constant grid. Else returns a P1-Lagrange gri
 """
 function regularDelaunayGrid(
             numnodes::Tuple{Int,Int}=(25, 25),
-            LL::AbstractVector=[0.0, 0.0],
-            UR::AbstractVector=[1.0, 1.0];
+            LL::Tuple{<:Real,<:Real}=(0.0, 0.0),
+            UR::Tuple{<:Real,<:Real}=(1.0, 1.0);
             quadrature_order::Int=default_quadrature_order,
-            on_torus=false,
-            on_cylinder=false,
-            nudge_epsilon::Float64=1e-5,
-            PC=false
+            on_torus::Bool=false,
+            on_cylinder::Bool=false,
+            nudge_epsilon::Real=1e-5,
+            PC::Bool=false
         )
-    X = range(LL[1],stop= UR[1],length= numnodes[1])
+    X = range(LL[1], stop=UR[1], length=numnodes[1])
     Y = range(LL[2], stop=UR[2], length=numnodes[2])
     if PC
         ip=JFM.PiecewiseConstant{2,JFM.RefTetrahedron,1}()
@@ -436,7 +431,7 @@ function regularDelaunayGrid(
         end
         node_list = nudge.(filter(x -> minimum(abs.(x .- UR)) > 1e-8, node_list))
     end
-    result = CoherentStructures.gridContext{2}(JFM.Triangle,
+    result = CoherentStructures.GridContext{2}(JFM.Triangle,
          node_list;
          quadrature_order=quadrature_order,
          on_torus=on_torus,
@@ -445,7 +440,7 @@ function regularDelaunayGrid(
          UR=UR,
          ip=ip,kwargs...
          )
-    result.spatialBounds = [LL, UR]
+    result.spatialBounds = (LL, UR)
     result.numberOfPointsInEachDirection = [numnodes[1], numnodes[2]]
     if !PC
         result.gridType = "regular P1 Delaunay grid"
@@ -453,9 +448,9 @@ function regularDelaunayGrid(
         result.gridType = "regular PC Delaunay grid"
     end
     if !PC
-        bdata = boundaryData(result, Dists.PeriodicEuclidean(UR .- LL))
+        bdata = BoundaryData(result, Dists.PeriodicEuclidean(UR .- LL))
     else
-        bdata = boundaryData()
+        bdata = BoundaryData()
     end
     return result, bdata
 end
@@ -463,12 +458,12 @@ end
 
 #= TODO 1.0
 """
-    gridContext{2}(JuAFEM.QuadraticTriangle, node_list, quadrature_order=default_quadrature_order)
+    GridContext{2}(JuAFEM.QuadraticTriangle, node_list, quadrature_order=default_quadrature_order)
 
 Create a P2 grid given a set of (non-interior) nodes using Delaunay Triangulation.
 """
 =#
-function gridContext{2}(
+function GridContext{2}(
             ::Type{JFM.QuadraticTriangle},
             node_list::Vector{Vec{2,Float64}};
             quadrature_order::Int=default_quadrature_order,
@@ -479,58 +474,56 @@ function gridContext{2}(
     qr = JFM.QuadratureRule{2, JFM.RefTetrahedron}(quadrature_order)
     push!(dh, :T, 1,ip) #The :T is just a generic name for the scalar field
     JFM.close!(dh)
-    result = gridContext{2}(grid, ip,JFM.Lagrange{2,JFM.RefTetrahedron,2}(), dh, qr, loc;kwargs...)
+    result = GridContext{2}(grid, ip,JFM.Lagrange{2,JFM.RefTetrahedron,2}(), dh, qr, loc;kwargs...)
     result.gridType = "irregular P2 Delaunay grid"
     return result
 end
 
 """
-    regularP2DelaunayGrid(numnodes=(25,25),LL=[0.0,0.0],UR=[1.0,1.0],quadrature_order=default_quadrature_order)
+    regularP2DelaunayGrid(numnodes=(25,25), LL=(0.0,0.0), UR=(1.0,1.0), quadrature_order=default_quadrature_order)
 
 Create a regular P2 triangular grid with `numnodes` being the number of (non-interior) nodes in each direction.
 """
 function regularP2DelaunayGrid(
             numnodes::Tuple{Int,Int}=(25, 25),
-            LL::AbstractVector=[0.0, 0.0],
-            UR::AbstractVector=[1.0, 1.0];
-            quadrature_order::Int=default_quadrature_order,kwargs...
-        )
-
+            LL::Tuple{<:Real,<:Real}=(0.0, 0.0),
+            UR::Tuple{<:Real,<:Real}=(1.0, 1.0);
+            quadrature_order::Int=default_quadrature_order, kwargs...)
     X = range(LL[1], stop=UR[1], length=numnodes[1])
     Y = range(LL[2], stop=UR[2], length=numnodes[2])
     node_list = vec([Vec{2}((x, y)) for y in Y, x in X])
-    result = gridContext{2}(JFM.QuadraticTriangle, node_list, quadrature_order=quadrature_order;kwargs...)
+    result = GridContext{2}(JFM.QuadraticTriangle, node_list, quadrature_order=quadrature_order;kwargs...)
     #TODO: Think about what values would be sensible for the two variables below
-    result.spatialBounds = [LL, UR]
+    result.spatialBounds = (LL, UR)
     result.numberOfPointsInEachDirection = [numnodes[1], numnodes[2]]
     result.gridType = "regular P2 Delaunay grid"
-    return result, boundaryData()
+    return result, BoundaryData()
 end
 
 #=
 """
-    gridContext{2}(JuAFEM.Triangle, numnodes, LL,UR; [quadrature_order])
+    GridContext{2}(JuAFEM.Triangle, numnodes, LL,UR; [quadrature_order])
 
 Create a regular triangular grid. Does not use Delaunay triangulation internally.
 """
 =#
 
-function gridContext{2}(::Type{JFM.Triangle},
+function GridContext{2}(::Type{JFM.Triangle},
                          numnodes::Tuple{Int,Int}=(25, 25),
-                         LL::AbstractVector=[0.0, 0.0],
-                         UR::AbstractVector=[1.0, 1.0];
+                         LL::Tuple{<:Real,<:Real}=(0.0, 0.0),
+                         UR::Tuple{<:Real,<:Real}=(1.0, 1.0);
                          quadrature_order::Int=default_quadrature_order,
                          ip=JFM.Lagrange{2,JFM.RefTetrahedron,1}(),kwargs...
                          )
     # The -1 below is needed because JuAFEM internally then goes on to increment it
     grid = JFM.generate_grid(JFM.Triangle, (numnodes[1]-1,numnodes[2]-1), Vec{2}(LL), Vec{2}(UR))
-    loc = regular2DGridLocator{JFM.Triangle}(numnodes[1], numnodes[2], Vec{2}(LL), Vec{2}(UR))
+    loc = Regular2DGridLocator{JFM.Triangle}(numnodes[1], numnodes[2], Vec{2}(LL), Vec{2}(UR))
     dh = JFM.DofHandler(grid)
     qr = JFM.QuadratureRule{2, JFM.RefTetrahedron}(quadrature_order)
-    push!(dh, :T, 1,ip) #The :T is just a generic name for the scalar field
+    push!(dh, :T, 1, ip) #The :T is just a generic name for the scalar field
     JFM.close!(dh)
-    result = gridContext{2}(grid, ip,JFM.Lagrange{2,JFM.RefTetrahedron,1}(), dh, qr, loc;kwargs...)
-    result.spatialBounds = [LL, UR]
+    result = GridContext{2}(grid, ip,JFM.Lagrange{2,JFM.RefTetrahedron,1}(), dh, qr, loc;kwargs...)
+    result.spatialBounds = (LL, UR)
     result.numberOfPointsInEachDirection = [numnodes[1], numnodes[2]]
     result.gridType = "regular triangular grid"
     return result
@@ -542,49 +535,48 @@ end
 Create a regular triangular grid on a rectangle; does not use Delaunay triangulation internally.
 If
 """
-function regularTriangularGrid(numnodes::Tuple{Int,Int}=(25,25),LL::AbstractVector=[0.0,0.0], UR::AbstractVector=[1.0,1.0];
-                                quadrature_order::Int=default_quadrature_order, PC=false,kwargs...)
+function regularTriangularGrid(numnodes::Tuple{Int,Int}=(25,25),
+                                LL::Tuple{<:Real,<:Real}=(0.0,0.0),
+                                UR::Tuple{<:Real,<:Real}=(1.0,1.0);
+                                quadrature_order::Int=default_quadrature_order,
+                                PC=false, kwargs...)
     if PC == false
         ip = JFM.Lagrange{2,JFM.RefTetrahedron,1}()
     else
-        ip = JFM.PiecewiseConstant{2,JuAFEMRefTetrahedron,1}()
+        ip = JFM.PiecewiseConstant{2,JFM.RefTetrahedron,1}()
     end
-    ctx =  gridContext{2}(JFM.Triangle,
-            numnodes, LL, UR;
+    ctx = GridContext{2}(JFM.Triangle, numnodes, LL, UR;
             quadrature_order=quadrature_order,ip=ip,kwargs...
             )
-    return ctx, boundaryData()
+    return ctx, BoundaryData()
 end
-
-
-
 
 #= TODO 1.0
 """
-    gridContext{2}(JuAFEM.QuadraticTriangle, numnodes=(25,25), LL=[0.0,0.0],UR=[1.0,1.0],quadrature_order=default_quadrature_order)
+    GridContext{2}(JuAFEM.QuadraticTriangle, numnodes=(25,25), LL=[0.0,0.0],UR=[1.0,1.0],quadrature_order=default_quadrature_order)
 
 Constructor for regular P2 triangular grids. Does not use Delaunay triangulation internally.
 """
 =#
-function gridContext{2}(::Type{JFM.QuadraticTriangle},
+function GridContext{2}(::Type{JFM.QuadraticTriangle},
                          numnodes::Tuple{Int,Int}=(25, 25),
-                         LL::AbstractVector=[0.0,0.0],
-                         UR::AbstractVector=[1.0,1.0];
+                         LL::Tuple{<:Real,<:Real}=(0.0,0.0),
+                         UR::Tuple{<:Real,<:Real}=(1.0,1.0);
                          quadrature_order::Int=default_quadrature_order,
-                         ip=JFM.Lagrange{2,JFM.RefTetrahedron,2}(),kwargs...
+                         ip=JFM.Lagrange{2,JFM.RefTetrahedron,2}(), kwargs...
                          )
     if !isa(ip,JFM.Lagrange)
         @warn "Using non-Lagrange interpolation with P2 elements may or may not work"
     end
     #The -1 below is needed because JuAFEM internally then goes on to increment it
     grid = JFM.generate_grid(JFM.QuadraticTriangle, (numnodes[1]-1,numnodes[2]-1), Vec{2}(LL), Vec{2}(UR))
-    loc = regular2DGridLocator{JFM.QuadraticTriangle}(numnodes[1], numnodes[2], Vec{2}(LL), Vec{2}(UR))
+    loc = Regular2DGridLocator{JFM.QuadraticTriangle}(numnodes[1], numnodes[2], Vec{2}(LL), Vec{2}(UR))
     dh = JFM.DofHandler(grid)
     qr = JFM.QuadratureRule{2, JFM.RefTetrahedron}(quadrature_order)
     push!(dh, :T, 1,ip) #The :T is just a generic name for the scalar field
     JFM.close!(dh)
-    result =  gridContext{2}(grid, ip,JFM.Lagrange{2,JFM.RefTetrahedron,2}(), dh, qr, loc;kwargs...)
-    result.spatialBounds = [LL, UR]
+    result =  GridContext{2}(grid, ip,JFM.Lagrange{2,JFM.RefTetrahedron,2}(), dh, qr, loc;kwargs...)
+    result.spatialBounds = (LL, UR)
     result.numberOfPointsInEachDirection = [numnodes[1], numnodes[2]]
     result.gridType = "regular P2 triangular grid"
     return result
@@ -592,44 +584,42 @@ end
 
 
 """
-    regularP2TriangularGrid(numnodes=(25,25), LL=[0.0,0.0],UR=[1.0,1.0],quadrature_order=default_quadrature_order)
+    regularP2TriangularGrid(numnodes=(25,25), LL=(0.0,0.0), UR=(1.0,1.0), quadrature_order=default_quadrature_order)
 
-Create a regular P2 triangular grid on a Rectangle. Does not use Delaunay triangulation internally.
+Create a regular P2 triangular grid on a rectangle. Does not use Delaunay triangulation internally.
 """
-function regularP2TriangularGrid(
-            numnodes::Tuple{Int,Int}=(25, 25), LL::AbstractVector=[0.0, 0.0], UR::AbstractVector=[1.0, 1.0];
-            quadrature_order::Int=default_quadrature_order,kwargs...
-        )
-    ctx = gridContext{2}(JFM.QuadraticTriangle, numnodes, LL, UR, quadrature_order=quadrature_order;kwargs...)
-    return ctx, boundaryData()
+function regularP2TriangularGrid(numnodes::Tuple{Int,Int}=(25, 25),
+                                    LL::Tuple{<:Real,<:Real}=(0.0,0.0),
+                                    UR=(1.0,1.0);
+                                    quadrature_order::Int=default_quadrature_order, kwargs...)
+    ctx = GridContext{2}(JFM.QuadraticTriangle, numnodes, LL, UR, quadrature_order=quadrature_order;kwargs...)
+    return ctx, BoundaryData()
 end
 
 #= TODO 1.0
 """
-    gridContext{2}(JuAFEM.Quadrilateral, numnodes=(25,25), LL=[0.0,0.0], UR=[1.0,1.0], quadrature_order=default_quadrature_order)
+    GridContext{2}(JuAFEM.Quadrilateral, numnodes=(25,25), LL=[0.0,0.0], UR=[1.0,1.0], quadrature_order=default_quadrature_order)
 
 Constructor for regular P1 quadrilateral grids.
 """
 =#
-function gridContext{2}(
-            ::Type{JFM.Quadrilateral},
-            numnodes::Tuple{Int,Int}=(25,25),
-            LL::AbstractVector=[0.0,0.0],
-            UR::AbstractVector=[1.0,1.0];
-            quadrature_order::Int=default_quadrature_order,
-            ip=JFM.Lagrange{2, JFM.RefCube, 1}(),kwargs...
-            )
+function GridContext{2}(::Type{JFM.Quadrilateral},
+                        numnodes::Tuple{Int,Int}=(25,25),
+                        LL::Tuple{<:Real,<:Real}=(0.0,0.0),
+                        UR::Tuple{<:Real,<:Real}=(1.0,1.0);
+                        quadrature_order::Int=default_quadrature_order,
+                        ip=JFM.Lagrange{2, JFM.RefCube, 1}(), kwargs...)
     #The -1 below is needed because JuAFEM internally then goes on to increment it
     grid = JFM.generate_grid(JFM.Quadrilateral, (numnodes[1]-1,numnodes[2]-1), Vec{2}(LL), Vec{2}(UR))
-    loc = regular2DGridLocator{JFM.Quadrilateral}(numnodes[1], numnodes[2], Vec{2}(LL), Vec{2}(UR))
+    loc = Regular2DGridLocator{JFM.Quadrilateral}(numnodes[1], numnodes[2], Vec{2}(LL), Vec{2}(UR))
     dh = JFM.DofHandler(grid)
     qr = JFM.QuadratureRule{2, JFM.RefCube}(quadrature_order)
     push!(dh, :T, 1,ip) #The :T is just a generic name for the scalar field
     JFM.close!(dh)
-    result =  gridContext{2}(grid, ip,JFM.Lagrange{2,JFM.RefCube,1}(), dh, qr, loc; kwargs...)
-    result.spatialBounds = [LL, UR]
+    result =  GridContext{2}(grid, ip,JFM.Lagrange{2,JFM.RefCube,1}(), dh, qr, loc; kwargs...)
+    result.spatialBounds = (LL, UR)
     result.numberOfPointsInEachDirection = [numnodes[1], numnodes[2]]
-    if isa(ip, JFM.Lagrange)
+    if ip isa JFM.Lagrange
         result.gridType = "regular P1 quadrilateral grid"
     else
         result.gridType = "regular PC quadrilateral grid"
@@ -638,59 +628,55 @@ function gridContext{2}(
 end
 
 """
-    regularP2QuadrilateralGrid(numnodes, LL,UR;[quadrature_order, PC=false]
+    regularP2QuadrilateralGrid(numnodes, LL, UR; [quadrature_order, PC=false])
 
-Create a regular P1 quadrilateral grid on a Rectangle. If `PC==true`, use
-piecewise constant shape functions. Else use P1 Lagrange.
+Create a regular P1 quadrilateral grid on a rectangle. If `PC==true`, use
+piecewise constant shape functions, otherwise use P1 Lagrange.
 """
-function regularQuadrilateralGrid(
-            numnodes::Tuple{Int,Int}=(25, 25),
-            LL::AbstractVector=[0.0, 0.0],
-            UR::AbstractVector=[1.0, 1.0];
-            quadrature_order::Int=default_quadrature_order,
-            PC=false,kwargs...
-        )
+function regularQuadrilateralGrid(numnodes::Tuple{Int,Int}=(25, 25),
+                                    LL::Tuple{<:Real,<:Real}=(0.0,0.0),
+                                    UR::Tuple{<:Real,<:Real}=(1.0,1.0);
+                                    quadrature_order::Int=default_quadrature_order,
+                                    PC=false, kwargs...)
     if !PC
         ip = JFM.Lagrange{2,JFM.RefCube,1}()
     else
         ip = JFM.PiecewiseConstant{2,JFM.RefCube,1}()
     end
-    ctx = gridContext{2}(JFM.Quadrilateral,
+    ctx = GridContext{2}(JFM.Quadrilateral,
          numnodes, LL, UR;
          quadrature_order=quadrature_order,
          ip=ip,kwargs...
      )
-     return ctx, boundaryData()
+     return ctx, BoundaryData()
 end
 
 
 #= TODO 1.0
 """
-    gridContext{2}(JuAFEM.QuadraticQuadrilateral, numnodes=(25,25), LL=[0.0,0.0],UR=[1.0,1.0],quadrature_order=default_quadrature_order)
+    GridContext{2}(JuAFEM.QuadraticQuadrilateral, numnodes=(25,25), LL=[0.0,0.0],UR=[1.0,1.0],quadrature_order=default_quadrature_order)
 
 Constructor for regular P2 quadrilateral grids.
 """
 =#
-function gridContext{2}(
-            ::Type{JFM.QuadraticQuadrilateral},
-            numnodes::Tuple{Int,Int}=(25, 25),
-            LL::AbstractVector=[0.0, 0.0],
-            UR::AbstractVector=[1.0, 1.0];
-            quadrature_order::Int=default_quadrature_order,
-            ip=JFM.Lagrange{2, JFM.RefCube, 2}(),kwargs...
-            )
-    if !isa(ip,JFM.Lagrange)
+function GridContext{2}(::Type{JFM.QuadraticQuadrilateral},
+                        numnodes::Tuple{Int,Int}=(25, 25),
+                        LL::Tuple{<:Real,<:Real}=(0.0,0.0),
+                        UR::Tuple{<:Real,<:Real}=(1.0,1.0);
+                        quadrature_order::Int=default_quadrature_order,
+                        ip=JFM.Lagrange{2, JFM.RefCube, 2}(), kwargs...)
+    if !isa(ip, JFM.Lagrange)
         @warn "Non-Lagrange interpolation with P2 elements may or may not work"
     end
     #The -1 below is needed because JuAFEM internally then goes on to increment it
     grid = JFM.generate_grid(JFM.QuadraticQuadrilateral, (numnodes[1]-1,numnodes[2]-1), Vec{2}(LL), Vec{2}(UR))
-    loc = regular2DGridLocator{JFM.QuadraticQuadrilateral}(numnodes[1], numnodes[2], Vec{2}(LL), Vec{2}(UR))
+    loc = Regular2DGridLocator{JFM.QuadraticQuadrilateral}(numnodes[1], numnodes[2], Vec{2}(LL), Vec{2}(UR))
     dh = JFM.DofHandler(grid)
     qr = JFM.QuadratureRule{2, JFM.RefCube}(quadrature_order)
     push!(dh, :T, 1,ip) #The :T is just a generic name for the scalar field
     JFM.close!(dh)
-    result =  gridContext{2}(grid, ip,JFM.Lagrange{2,JFM.RefCube,2}(), dh, qr, loc;kwargs...)
-    result.spatialBounds = [LL, UR]
+    result =  GridContext{2}(grid, ip,JFM.Lagrange{2,JFM.RefCube,2}(), dh, qr, loc;kwargs...)
+    result.spatialBounds = (LL, UR)
     result.numberOfPointsInEachDirection = [numnodes[1], numnodes[2]]
     result.gridType = "regular P2 quadrilateral grid"
     return result
@@ -698,44 +684,42 @@ end
 
 
 """
-    regularP2QuadrilateralGrid(numnodes=(25,25), LL=[0.0,0.0], UR=[1.0,1.0], quadrature_order=default_quadrature_order)
+    regularP2QuadrilateralGrid(numnodes=(25,25), LL=(0.0,0.0), UR=(1.0,1.0), quadrature_order=default_quadrature_order)
 
 Create a regular P2 quadrilateral grid on a rectangle.
 """
-function regularP2QuadrilateralGrid(
-            numnodes::Tuple{Int,Int}=(25,25),
-            LL::AbstractVector=[0.0, 0.0],
-            UR::AbstractVector=[1.0, 1.0];
-            quadrature_order::Int=default_quadrature_order,kwargs...
-        )
-    ctx = gridContext{2}(JFM.QuadraticQuadrilateral, numnodes, LL, UR, quadrature_order=quadrature_order,kwargs...)
-    return ctx, boundaryData()
+function regularP2QuadrilateralGrid(numnodes::Tuple{Int,Int}=(25,25),
+                                    LL::Tuple{<:Real,<:Real}=(0.0,0.0),
+                                    UR=(1.0,1.0);
+                                    quadrature_order::Int=default_quadrature_order, kwargs...)
+    ctx = GridContext{2}(JFM.QuadraticQuadrilateral, numnodes, LL, UR, quadrature_order=quadrature_order,kwargs...)
+    return ctx, BoundaryData()
 end
+
 #=TODO 1.0
 """
-    gridContext{3}(JuAFEM.Tetrahedron, numnodes=(10,10,10), LL=[0.0,0.0,0.0], UR=[1.0,1.0,1.0], quadrature_order=default_quadrature_order3D)
+    GridContext{3}(JuAFEM.Tetrahedron, numnodes=(10,10,10), LL=[0.0,0.0,0.0], UR=[1.0,1.0,1.0], quadrature_order=default_quadrature_order3D)
 
 Create a regular P1 Tetrahedral Grid in 3D.
 """
 =#
-function gridContext{3}(::Type{JFM.Tetrahedron},
+function GridContext{3}(::Type{JFM.Tetrahedron},
                          numnodes::Tuple{Int,Int,Int}=(10,10,10),
-                         LL::AbstractVector=[0.0,0.0,0.0],
-                         UR::AbstractVector=[1.0,1.0,1.0];
+                         LL::Tuple{<:Real,<:Real,<:Real}=(0.0,0.0,0.0),
+                         UR::Tuple{<:Real,<:Real,<:Real}=(1.0,1.0,1.0);
                          quadrature_order::Int=default_quadrature_order3D,
-                         ip=JFM.Lagrange{3, JFM.RefTetrahedron, 1}(),kwargs...
-                         )
+                         ip=JFM.Lagrange{3, JFM.RefTetrahedron, 1}(), kwargs...)
     #The -1 below is needed because JuAFEM internally then goes on to increment it
     grid = JFM.generate_grid(JFM.Tetrahedron, (numnodes[1]-1, numnodes[2]-1, numnodes[3] -1), Vec{3}(LL), Vec{3}(UR))
-    loc = regular3DGridLocator{JFM.Tetrahedron}(numnodes[1], numnodes[2], numnodes[3], Vec{3}(LL), Vec{3}(UR))
+    loc = Regular3DGridLocator{JFM.Tetrahedron}(numnodes[1], numnodes[2], numnodes[3], Vec{3}(LL), Vec{3}(UR))
     dh = JFM.DofHandler(grid)
     qr = JFM.QuadratureRule{3, JFM.RefTetrahedron}(quadrature_order)
     push!(dh, :T, 1,ip) #The :T is just a generic name for the scalar field
     JFM.close!(dh)
-    result =  gridContext{3}(grid, ip,JFM.Lagrange{3,JFM.RefTetrahedron,1}(), dh, qr, loc;kwargs...)
-    result.spatialBounds = [LL, UR]
+    result =  GridContext{3}(grid, ip,JFM.Lagrange{3,JFM.RefTetrahedron,1}(), dh, qr, loc;kwargs...)
+    result.spatialBounds = (LL, UR)
     result.numberOfPointsInEachDirection = [numnodes[1], numnodes[2], numnodes[3]]
-    if isa(ip, JFM.Lagrange)
+    if ip isa JFM.Lagrange
         result.gridType = "3D P1 regular tetrahedral grid"
     else
        result.gridType = "3D PC regular tetrahedral grid"
@@ -746,70 +730,70 @@ end
 
 #=TODO 1.0
 """
-    gridContext{3}(JuAFEM.QuadraticTetrahedron, numnodes=(10,10,10), LL=[0.0,0.0,0.0], UR=[1.0,1.0,1.0], quadrature_order=default_quadrature_order3D)
+    GridContext{3}(JuAFEM.QuadraticTetrahedron, numnodes=(10,10,10), LL=[0.0,0.0,0.0], UR=[1.0,1.0,1.0], quadrature_order=default_quadrature_order3D)
 
 Create a regular P2 Tetrahedral Grid in 3D.
 """
 =#
-function gridContext{3}(::Type{JFM.QuadraticTetrahedron},
+function GridContext{3}(::Type{JFM.QuadraticTetrahedron},
                          numnodes::Tuple{Int,Int,Int}=(10,10,10),
-                         LL::AbstractVector=[0.0,0.0,0.0],
-                         UR::AbstractVector=[1.0,1.0,1.0];
+                         LL::Tuple{<:Real,<:Real,<:Real}=(0.0,0.0,0.0),
+                         UR::Tuple{<:Real,<:Real,<:Real}=(1.0,1.0,1.0);
                          quadrature_order::Int=default_quadrature_order3D,
-                         ip=JFM.Lagrange{3, JFM.RefTetrahedron, 2}(),kwargs...
-                         )
+                         ip=JFM.Lagrange{3, JFM.RefTetrahedron, 2}(), kwargs...)
     if !isa(ip, JuAFEM.Lagrange)
         @warn "Using non-Lagrange interpolation with P2 Elements may or may not work"
     end
     #The -1 below is needed because JuAFEM internally then goes on to increment it
     grid = JFM.generate_grid(JFM.QuadraticTetrahedron, (numnodes[1]-1, numnodes[2]-1, numnodes[3] -1), Vec{3}(LL), Vec{3}(UR))
-    loc = regular3DGridLocator{JFM.QuadraticTetrahedron}(numnodes[1], numnodes[2], numnodes[3], Vec{3}(LL), Vec{3}(UR))
+    loc = Regular3DGridLocator{JFM.QuadraticTetrahedron}(numnodes[1], numnodes[2], numnodes[3], Vec{3}(LL), Vec{3}(UR))
     dh = JFM.DofHandler(grid)
     qr = JFM.QuadratureRule{3, JFM.RefTetrahedron}(quadrature_order)
     push!(dh, :T, 1,ip) #The :T is just a generic name for the scalar field
     JFM.close!(dh)
-    result =  gridContext{3}(grid, ip,JFM.Lagrange{3,JFM.RefTetrahedron,2}(), dh, qr, loc;kwargs...)
-    result.spatialBounds = [LL, UR]
+    result =  GridContext{3}(grid, ip,JFM.Lagrange{3,JFM.RefTetrahedron,2}(), dh, qr, loc;kwargs...)
+    result.spatialBounds = (LL, UR)
     result.numberOfPointsInEachDirection = [numnodes[1], numnodes[2], numnodes[3]]
     result.gridType = "3D regular P2 tetrahedral grid"
     return result
 end
 
 """
-    regularTetrahedralGrid(numnodes=(10,10,10), LL=[0.0,0.0,0.0], UR=[1.0,1.0,1.0], quadrature_order=default_quadrature_order3D)
+    regularTetrahedralGrid(numnodes=(10,10,10), LL=(0.0,0.0,0.0), UR=(1.0,1.0,1.0), quadrature_order=default_quadrature_order3D)
 
 Create a regular P1 tetrahedral grid on a Cuboid in 3D. Does not use Delaunay triangulation internally.
 """
 function regularTetrahedralGrid(
-        numnodes::Tuple{Int,Int,Int}=(10,10,10),
-        LL::AbstractVector=[0.0,0.0,0.0],
-        UR::AbstractVector=[1.0,1.0,1.0];
-        quadrature_order::Int=default_quadrature_order3D, PC=false,kwargs...
-        )
+        numnodes::NTuple{3,Int}=(10,10,10),
+        LL::Tuple{<:Real,<:Real,<:Real}=(0.0,0.0,0.0),
+        UR::Tuple{<:Real,<:Real,<:Real}=(1.0,1.0,1.0);
+        quadrature_order::Int=default_quadrature_order3D, PC=false, kwargs...)
     if !PC
         ip = JFM.Lagrange{3,JFM.RefTetrahedron,1}()
     else
         ip = JFM.PiecewiseConstant{3,JFM.RefTetrahedron,1}()
     end
-    ctx =  gridContext{3}(JFM.Tetrahedron,
+    ctx =  GridContext{3}(JFM.Tetrahedron,
         numnodes, LL, UR;
         quadrature_order=quadrature_order,ip=ip, kwargs...
         )
-    return ctx, boundaryData()
+    return ctx, BoundaryData()
 end
 
 """
-    regularP2TetrahedralGrid(numnodes=(10,10,10), LL=[0.0,0.0,0.0], UR=[1.0,1.0,1.0], quadrature_order=default_quadrature_order3D)
+    regularP2TetrahedralGrid(numnodes=(10,10,10), LL=(0.0,0.0,0.0), UR=(1.0,1.0,1.0), quadrature_order=default_quadrature_order3D)
 
 Create a regular P2 tetrahedral grid on a Cuboid in 3D. Does not use Delaunay triangulation internally.
 """
-function regularP2TetrahedralGrid(numnodes::Tuple{Int,Int,Int}=(10,10,10), LL::AbstractVector=[0.0,0.0,0.0], UR::AbstractVector=[1.0,1.0,1.0];
-                                    quadrature_order::Int=default_quadrature_order3D,kwargs...)
-    ctx =  gridContext{3}(JFM.QuadraticTetrahedron,
+function regularP2TetrahedralGrid(numnodes::Tuple{Int,Int,Int}=(10,10,10),
+                                    LL::Tuple{<:Real,<:Real,<:Real}=(0.0,0.0,0.0),
+                                    UR::Tuple{<:Real,<:Real,<:Real}=(1.0,1.0,1.0);
+                                    quadrature_order::Int=default_quadrature_order3D,
+                                    kwargs...)
+    ctx = GridContext{3}(JFM.QuadraticTetrahedron,
         numnodes, LL, UR;
-        quadrature_order=quadrature_order, kwargs...
-        )
-    return ctx, boundaryData()
+        quadrature_order=quadrature_order, kwargs...)
+    return ctx, BoundaryData()
 end
 
 
@@ -821,7 +805,7 @@ sure it is within `ctx.spatialBounds` (if `project_in==true`).
 Helper function.
 """
 function project_in_xin(
-    ctx::gridContext{dim}, x_in::AbstractVector{T},project_in
+    ctx::GridContext{dim}, x_in::AbstractVector{T},project_in
     )::Vec{dim,T} where {dim,T}
 
     if !project_in
@@ -868,8 +852,8 @@ assumed to be in node order. This is more efficient than
 `evaluate_function_from_dofvals`.
 """
 function evaluate_function_from_node_or_cellvals(
-    ctx::gridContext{dim}, vals::AbstractVector{S}, x_in::Vec{dim,W};
-    outside_value=NaN, project_in=false,throw_errors=true)::S where {dim,S,W}
+    ctx::GridContext{dim}, vals::AbstractVector{S}, x_in::Vec{dim,W};
+    outside_value=NaN, project_in=false, throw_errors=true)::S where {dim,S,W}
 
     x::Vec{dim,W} = project_in_xin(ctx,x_in,project_in)
 
@@ -878,7 +862,7 @@ function evaluate_function_from_node_or_cellvals(
     local_coordinates::Vec{dim,W}, nodes::Vector{Int}, cellid::Int = try
          locatePoint(ctx, x)
     catch y
-        if isa(y,DomainError)
+        if y isa DomainError
             return outside_value
         end
         if throw_errors
@@ -891,12 +875,12 @@ function evaluate_function_from_node_or_cellvals(
 
     result::S = zero(S)
 
-    if isa(ctx.ip, JFM.Lagrange)
+    if ctx.ip isa JFM.Lagrange
         for (j, nodeid) in enumerate(nodes)
-            val::W = JFM.value(ctx.ip, j, local_coordinates)
+            val = JFM.value(ctx.ip, j, local_coordinates)
             result += vals[nodeid]*val
         end
-    elseif isa(ctx.ip,JFM.PiecewiseConstant)
+    elseif ctx.ip isa JFM.PiecewiseConstant
         val = JFM.value(ctx.ip, 1, local_coordinates)
         result += vals[cellid]*val
     else
@@ -911,8 +895,8 @@ end
 Like `evaluate_function_from_node_or_cellvals` but with more type-restrictions and ForwardDiff compatibility.
 """
 function evaluate_function_from_node_or_cellvalsFDiff(
-    ctx::gridContext{dim}, vals::Vector{Float64}, x_in::Vec{dim,W};
-    outside_value=NaN, project_in=false,throw_errors=true)::W where {dim,W}
+    ctx::GridContext{dim}, vals::Vector{Float64}, x_in::Vec{dim,W};
+    outside_value=NaN, project_in=false, throw_errors=true)::W where {dim,W}
 
     x::Vec{dim,W} = project_in_xin(ctx,x_in,project_in)
 
@@ -921,7 +905,7 @@ function evaluate_function_from_node_or_cellvalsFDiff(
     local_coordinates::Vec{dim,W}, nodes::Vector{Int}, cellid::Int = try
          locatePoint(ctx, x)
     catch y
-        if isa(y,DomainError)
+        if y isa DomainError
             return outside_value
         end
         if throw_errors
@@ -934,12 +918,12 @@ function evaluate_function_from_node_or_cellvalsFDiff(
 
     result::W = zero(W)
 
-    if isa(ctx.ip, JFM.Lagrange)
+    if ctx.ip isa JFM.Lagrange
         for (j, nodeid) in enumerate(nodes)
             val::W = JFM.value(ctx.ip, j, local_coordinates)
             result += vals[nodeid]*val
         end
-    elseif isa(ctx.ip,JFM.PiecewiseConstant)
+    elseif ctx.ip isa JFM.PiecewiseConstant
         val = JFM.value(ctx.ip, 1, local_coordinates)
         result += vals[cellid]*val
     else
@@ -958,10 +942,10 @@ For evaluation at many points, or for many dofvals, the function `evaluate_funct
 is more efficient.
 """
 function evaluate_function_from_dofvals(
-    ctx::gridContext{dim}, vals::AbstractVector{S}, x_in::Vec{dim,W};
+    ctx::GridContext{dim}, vals::AbstractVector{S}, x_in::Vec{dim,W};
     outside_value=NaN, project_in=false)::S where {dim,S,W}
 
-    if isa(ctx.ip, JFM.Lagrange)
+    if ctx.ip isa JFM.Lagrange
         vals_reorder = vals[ctx.node_to_dof]
     else
         vals_reorder = vals[ctx.cell_to_dof]
@@ -982,10 +966,10 @@ ordering for `vals`, which makes it slightly more efficient.
 If vals is a diagonal matrix, set `is_diag` to `true` for much faster evaluation.
 """
 function evaluate_function_from_node_or_cellvals_multiple(
-    ctx::gridContext{dim}, vals::AbstractMatrix{S},
-    x_in::AbstractVector{Vec{dim,W}};
-    outside_value=NaN, project_in=false, is_diag=false, throw_errors=false
-    )::SparseMatrixCSC{S,Int64} where {dim,S,W}
+            ctx::GridContext{dim}, vals::AbstractMatrix{S},
+            x_in::AbstractVector{<:Vec{dim,W}};
+            outside_value=NaN, project_in=false, is_diag=false, throw_errors=false
+            )::SparseMatrixCSC{S,Int64} where {dim,S,W}
 
 
     x::Vector{Vec{dim,W}} = [project_in_xin(ctx, x_cur, project_in) for x_cur in x_in]
@@ -1002,9 +986,9 @@ function evaluate_function_from_node_or_cellvals_multiple(
         rows_tmp = Int[]
         vals_tmp = S[]
         try
-            local_coordinates::Vec{dim,W}, nodes::Vector{Int},cellid::Int = locatePoint(ctx,x[current_point])
+            local_coordinates::Vec{dim,W}, nodes::Vector{Int}, cellid::Int = locatePoint(ctx, x[current_point])
 
-            if isa(ctx.ip, JFM.Lagrange)
+            if ctx.ip isa JFM.Lagrange
                 if !is_diag
                     for i in 1:(size(vals)[2])
                         summed_value = 0.0
@@ -1018,11 +1002,11 @@ function evaluate_function_from_node_or_cellvals_multiple(
                 else
                     for (j, nodeid) in enumerate(nodes)
                         val = JFM.value(ctx.ip, j, local_coordinates)
-                        push!(rows_tmp,nodeid)
+                        push!(rows_tmp, nodeid)
                         push!(vals_tmp,vals[nodeid,nodeid]*val)
                     end
                 end
-            elseif isa(ctx.ip,JFM.PiecewiseConstant)
+            elseif ctx.ip isa JFM.PiecewiseConstant
                 val = JFM.value(ctx.ip, 1, local_coordinates)
                 if !is_diag
                     for i in 1:(size(vals)[2])
@@ -1037,22 +1021,22 @@ function evaluate_function_from_node_or_cellvals_multiple(
                 throw(AssertionError("Unknown interpolation"))
             end
         catch y
-                if isa(y,DomainError)
+            if y isa DomainError
+                if outside_value != 0.0
+                    rows_tmp=collect(1:(size(vals)[2]))
+                    vals_tmp=[outside_value for i in 1:(size(vals)[2])]
+                end
+            else
+                if throw_errors
+                    print("Unexpected error for $(x[current_point])")
+                    rethrow(y)
+                else
                     if outside_value != 0.0
-                        rows_tmp=collect(1:(size(vals)[2]))
+                        rows_tmp=collect(1:size(vals)[2])
                         vals_tmp=[outside_value for i in 1:(size(vals)[2])]
                     end
-                else
-                    if throw_errors
-                        print("Unexpected error for $(x[current_point])")
-                        rethrow(y)
-                    else
-                        if outside_value != 0.0
-                            rows_tmp=collect(1:size(vals)[2])
-                            vals_tmp=[outside_value for i in 1:(size(vals)[2])]
-                        end
-                    end
                 end
+            end
         end
         ordering = sortperm(rows_tmp)
         append!(result_rows,rows_tmp[ordering])
@@ -1076,81 +1060,76 @@ The function is evaluated for each column.
 If caught exceptions should be rethrown, set `throw_errors=true`
 """
 function evaluate_function_from_dofvals_multiple(
-    ctx::gridContext{dim}, dofvals::AbstractMatrix{S},
-    x_in::AbstractVector{Vec{dim,W}};
-    outside_value=NaN, project_in=false,throw_errors=false
-    )::SparseMatrixCSC{S,Int64} where { dim,S,W, }
-    u_vals = zeros(S,size(dofvals))
-    if isa(ctx.ip, JFM.Lagrange)
+            ctx::GridContext{dim}, dofvals::AbstractMatrix{S},
+            x_in::AbstractVector{<:Vec{dim}};
+            outside_value=NaN, project_in=false,throw_errors=false
+            )::SparseMatrixCSC{S,Int64} where {dim,S}
+    u_vals = zeros(S, size(dofvals))
+    if ctx.ip isa JFM.Lagrange
         for i in 1:ctx.n
             u_vals[i,:] = dofvals[ctx.node_to_dof[i],:]
         end
-    elseif isa(ctx.ip, JFM.PiecewiseConstant)
+    elseif ctx.ip isa JFM.PiecewiseConstant
         for i in 1:ctx.n
             u_vals[i,:] = dofvals[ctx.cell_to_dof[i],:]
         end
     end
-    return evaluate_function_from_node_or_cellvals_multiple(ctx,u_vals, x_in,outside_value=outside_value,project_in=project_in,throw_errors=throw_errors)
+    return evaluate_function_from_node_or_cellvals_multiple(ctx, u_vals, x_in;
+                outside_value=outside_value, project_in=project_in, throw_errors=throw_errors)
 end
 
 
 
 """
-    sample_to(u::Vector{T},ctx_old,ctx_new;[bdata=boundaryData(),project_in=true,outside_value=NaN])
+    sample_to(u::Vector{T},ctx_old,ctx_new;[bdata=BoundaryData(),project_in=true,outside_value=NaN])
 
 Perform nodal_interpolation of a function onto a different grid.
 """
-function sample_to(u::Vector{T}, ctx_old::CoherentStructures.gridContext, ctx_new::CoherentStructures.gridContext;
-    bdata=boundaryData(),project_in=true,outside_value=NaN,
-    ) where {T}
-    if !isa(ctx_new.ip,JFM.Lagrange)
+function sample_to(u::Vector{T}, ctx_old::GridContext, ctx_new::GridContext;
+        bdata=BoundaryData(), project_in=true, outside_value=NaN) where {T}
+    if !isa(ctx_new.ip, JFM.Lagrange)
         throw(AssertionError("Nodal interpolation only defined for Lagrange elements"))
-    end
-    if isa(ctx_old.ip,JFM.Lagrange)
-        u_node_or_cellvals = undoBCS(ctx_old, u,bdata)[ctx_old.node_to_dof]
     else
-        u_node_or_cellvals = undoBCS(ctx_old, u,bdata)[ctx_old.cell_to_dof]
+        u_node_or_cellvals = undoBCS(ctx_old, u, bdata)[ctx_old.node_to_dof]
     end
     return nodal_interpolation(ctx_new,
-                x -> evaluate_function_from_node_or_cellvals(ctx_old,u_node_or_cellvals,x;
-                        outside_value=outside_value, project_in=project_in)
-                    )
+                x -> evaluate_function_from_node_or_cellvals(ctx_old, u_node_or_cellvals, x;
+                outside_value=outside_value, project_in=project_in))
 end
 
 """
-    sample_to(u::AbstractArray{2,T},ctx_old,ctx_new; [bdata=boundaryData(),project_in=true,outside_value=NaN])
+    sample_to(u::AbstractArray{2,T},ctx_old,ctx_new; [bdata=BoundaryData(),project_in=true,outside_value=NaN])
 
 Perform nodal_interpolation of a function onto a different grid for a set of columns of a matrix.
 Returns a matrix
 """
-function sample_to(u::AbstractArray{T,2},
-        ctx_old::CoherentStructures.gridContext,
-        ctx_new::CoherentStructures.gridContext;
-        bdata=boundaryData(),
+function sample_to(u::AbstractMatrix{T},
+        ctx_old::CoherentStructures.GridContext,
+        ctx_new::CoherentStructures.GridContext;
+        bdata=BoundaryData(),
         project_in=true,
         outside_value=NaN
         ) where {T}
 
-    if !isa(ctx_new.ip,JFM.Lagrange)
+    if !isa(ctx_new.ip, JFM.Lagrange)
         throw(AssertionError("Nodal interpolation only defined for Lagrange elements"))
     end
 
     ncols = size(u)[2]
-    u_node_or_cellvals = zeros(T, ctx_old.n,ncols)
+    u_node_or_cellvals = zeros(T, ctx_old.n, ncols)
     for j in 1:ncols
-        if isa(ctx_old.ip, JFM.Lagrange)
+        if ctx_old.ip isa JFM.Lagrange
             u_node_or_cellvals[:,j] .= undoBCS(ctx_old,u[:,j],bdata)[ctx_old.node_to_dof]
         else
             u_node_or_cellvals[:,j] .= undoBCS(ctx_old,u[:,j],bdata)[ctx_old.cell_to_dof]
         end
     end
     #TODO: Maybe make this more efficient by calling evaluate_function_from_node_or_cellvals_multiple
-    ctx_new_gridpoints = [x.x for x in ctx_new.grid.nodes]
-    u_new::Array{T,2} = zeros(T,ctx_new.n,ncols)*NaN
+    ctx_new_gridpoints = [p.x for p in ctx_new.grid.nodes]
+    u_new = zeros(T, ctx_new.n, ncols)*NaN
     for j in 1:ncols
         u_new[:,j] = evaluate_function_from_node_or_cellvals_multiple(ctx_old, u_node_or_cellvals[:,j:j], ctx_new_gridpoints;
-            outside_value=outside_value, project_in=project_in
-            )[ctx_new.dof_to_node]
+            outside_value=outside_value, project_in=project_in)[ctx_new.dof_to_node]
     end
     return u_new
 end
@@ -1260,13 +1239,12 @@ Function for creating a grid from scattered nodes.
 Calls VoronoiDelaunay for delaunay triangulation. Makes a periodic triangulation
 if `on_torus` is set to `true` similarly with `on_cylinder`.
 """
-function JuAFEM.generate_grid(::Type{JFM.Triangle},
+function JFM.generate_grid(::Type{JFM.Triangle},
      nodes_in::Vector{Vec{2,Float64}};
-     on_torus=false,on_cylinder=false,LL=nothing,UR=nothing
-     )
+     on_torus=false, on_cylinder=false, LL=nothing, UR=nothing)
     @assert !(on_torus && on_cylinder)
     if on_torus || on_cylinder
-        @assert !(LL == nothing || UR == nothing)
+        @assert !(LL === nothing || UR === nothing)
     end
 
     #How many nodes were supplied
@@ -1283,10 +1261,10 @@ function JuAFEM.generate_grid(::Type{JFM.Triangle},
         dx = UR[1] - LL[1]
         dy = UR[2] - LL[2]
         for i in (0, 1, -1), j in (0, 1, -1)
-            for (index,node) in enumerate(nodes_in)
-                new_point = node .+ (i*dx,j*dy)
-                push!(nodes_to_triangulate,Vec{2}((new_point[1],new_point[2])))
-                push!(points_mapping,index)
+            for (index, node) in enumerate(nodes_in)
+                new_point = node .+ (i*dx, j*dy)
+                push!(nodes_to_triangulate,Vec{2}((new_point[1], new_point[2])))
+                push!(points_mapping, index)
             end
         end
     elseif on_cylinder
@@ -1294,16 +1272,16 @@ function JuAFEM.generate_grid(::Type{JFM.Triangle},
         dy = UR[2] - LL[2]
         for i in (0, 1, -1)
             j = 0
-            for (index,node) in enumerate(nodes_in)
-                new_point = node .+ (i*dx,j*dy)
-                push!(nodes_to_triangulate,Vec{2}((new_point[1],new_point[2])))
-                push!(points_mapping,index)
+            for (index, node) in enumerate(nodes_in)
+                new_point = node .+ (i*dx, j*dy)
+                push!(nodes_to_triangulate, Vec{2}((new_point[1], new_point[2])))
+                push!(points_mapping, index)
             end
         end
     else
-        for (index,node) in enumerate(nodes_in)
-            push!(nodes_to_triangulate,node)
-            push!(points_mapping,index)
+        for (index, node) in enumerate(nodes_in)
+            push!(nodes_to_triangulate, node)
+            push!(points_mapping, index)
         end
     end
 
@@ -1344,7 +1322,7 @@ function JuAFEM.generate_grid(::Type{JFM.Triangle},
 
     tri_iterator = Base.iterate(tess)
     while tri_iterator != nothing
-        (tri,triindex) = tri_iterator
+        (tri, triindex) = tri_iterator
         #It could be the the triangle in question is oriented the wrong way
         #We test this, and flip it if neccessary
         J = Tensors.otimes((nodes_to_triangulate[switched_nodes_table[tri._b.id]] - nodes_to_triangulate[switched_nodes_table[tri._a.id]]), e1)
@@ -1370,13 +1348,13 @@ function JuAFEM.generate_grid(::Type{JFM.Triangle},
                 #version of this cell
                 thiscell = in_cells_used(cells_used,
                                     Tuple{Int,Int,Int}(new_tri_nodes_from_tess),
-                                    num_nodes_in,on_cylinder)
+                                    num_nodes_in, on_cylinder)
                 if thiscell != 0
                     #We have, so nothing to do here except record this.
                    cell_number_table[triindex.ix-1] = thiscell
                 else
                     #Now iterate over the nodes of the cell
-                    for (index,cur) in enumerate(tri_nodes)
+                    for (index, cur) in enumerate(tri_nodes)
                         #Is this one of the "original" nodes?
                         if cur <= num_nodes_in
                             #Let's record that we've seen it
@@ -1421,7 +1399,7 @@ function JuAFEM.generate_grid(::Type{JFM.Triangle},
                 cells_to_deal_with[Tuple{Int,Int,Int}(tri_nodes)] = triindex.ix-1
             end
         end
-        tri_iterator = Base.iterate(tess,triindex)
+        tri_iterator = Base.iterate(tess, triindex)
     end
     #Write down location of remaining cells
     if on_torus || on_cylinder
@@ -1444,7 +1422,7 @@ function JuAFEM.generate_grid(::Type{JFM.Triangle},
     #boundary_matrix = spzeros(Bool, 3, m)#TODO:Maybe treat the boundary correctly?
     #TODO: Fix below if this doesn't work
     grid = JFM.Grid(cells, nodes)#, facesets=facesets, boundary_matrix=boundary_matrix)
-    locator = delaunayCellLocator(m, scale_x, scale_y, min_x, min_y, tess,nodes_to_triangulate[switched_nodes_table],points_mapping,cell_number_table)
+    locator = DelaunayCellLocator(m, scale_x, scale_y, min_x, min_y, tess,nodes_to_triangulate[switched_nodes_table], points_mapping, cell_number_table)
     return grid, locator
 end
 
@@ -1457,7 +1435,7 @@ function JuAFEM.generate_grid(::Type{JFM.QuadraticTriangle}, nodes_in::Vector{Ve
     points_mapping = Vector{Int}[]
 
     tess, m, scale_x, scale_y, minx, miny = delaunay2(nodes_to_triangulate)
-    locator = p2DelaunayCellLocator(m, scale_x, scale_y, minx, miny, tess,points_mapping)
+    locator = P2DelaunayCellLocator(m, scale_x, scale_y, minx, miny, tess,points_mapping)
     nodes = map(JFM.Node, nodes_in)
     n = length(nodes)
     ctr = n #As we add nodes (for edge vertices), increment the ctr...
@@ -1514,11 +1492,10 @@ end
 """
     nodal_interpolation(ctx,f)
 
-Perform nodal interpolation of a function. Returns a vector of coefficients in dof order
+Perform nodal interpolation of a function. Returns a vector of coefficients in dof order.
 """
-function nodal_interpolation(ctx::gridContext, f::Function)
-    nodal_values = [f(ctx.grid.nodes[ctx.dof_to_node[j]].x) for j in 1:ctx.n]
-    return nodal_values
+function nodal_interpolation(ctx::GridContext, f::Function)
+    return [f(ctx.grid.nodes[ctx.dof_to_node[j]].x) for j in 1:ctx.n]
 end
 
 """
@@ -1527,10 +1504,10 @@ end
 Returns the midpoint of the cell `cellindex`
 """
 
-function getCellMidpoint(ctx,cellindex)
+function getCellMidpoint(ctx, cellindex)
     cell = ctx.grid.cells[cellindex]
     nnodes = length(cell.nodes)
-    result = Vec{2}((0.0,0.0))
+    result = Vec((0.0, 0.0))
     for i in 1:length(cell.nodes)
         result += ctx.grid.nodes[cell.nodes[i]].x
     end
@@ -1540,6 +1517,17 @@ end
 
 ###P2 Grids in 3D:
 #TODO: See if this can be moved upstream
+
+const localnodes = [((1,1,1),(3,1,1),(1,3,1),(1,3,3)),
+                    ((1,1,1),(1,1,3),(3,1,1),(1,3,3)),
+                    ((3,1,1),(3,3,1),(1,3,1),(1,3,3)),
+                    ((3,1,1),(3,3,3),(3,3,1),(1,3,3)),
+                    ((3,1,1),(1,1,3),(3,1,3),(1,3,3)),
+                    ((3,1,1),(3,1,3),(3,3,3),(1,3,3))
+                    ]
+
+_avg(x, y) = (x == 1 && y == 3) || (x == 3 && y == 1) ? 2 : x
+_indexavg(x, y) = CartesianIndex(_avg.(Tuple(x), Tuple(y)))
 
 #Based on JuAFEM's generate_grid(Tetrahedron, ...) function
 function JuAFEM.generate_grid(::Type{JFM.QuadraticTetrahedron}, cells_per_dim::NTuple{3,Int}, left::Vec{3,T}=Vec{3}((-1.0,-1.0,-1.0)), right::Vec{3,T}=Vec{3}((1.0,1.0,1.0))) where {T}
@@ -1578,21 +1566,11 @@ function JuAFEM.generate_grid(::Type{JFM.QuadraticTetrahedron}, cells_per_dim::N
     #TODO add @inbounds once this works...
     for k in 1:n_cells_z, j in 1:n_cells_y, i in 1:n_cells_x
         cube = numbering[(2*(i-1) + 1):(2*i + 1), (2*(j-1)+1): 2*j + 1, (2*(k-1) +1): (2*k +1)]
-
-        localnodes = [  ((1,1,1),(3,1,1),(1,3,1),(1,3,3)),
-                        ((1,1,1),(1,1,3),(3,1,1),(1,3,3)),
-                        ((3,1,1),(3,3,1),(1,3,1),(1,3,3)),
-                        ((3,1,1),(3,3,3),(3,3,1),(1,3,3)),
-                        ((3,1,1),(1,1,3),(3,1,3),(1,3,3)),
-                        ((3,1,1),(3,1,3),(3,3,3),(1,3,3))
-                        ]
-        avg(x,y) = (x == 1 && y == 3) || (x == 3 && y == 1) ? 2 : x
-        indexavg(x,y) = CartesianIndex(avg.(Tuple(x),Tuple(y)))
         for (idx, p1vertices) in enumerate(localnodes)
             v1,v2,v3,v4 = map(CartesianIndex,p1vertices)
-            cells[cell_idx + idx] = JFM.QuadraticTetrahedron((cube[v1],cube[v2],cube[v3],cube[v4],
-                        cube[indexavg(v1,v2)],cube[indexavg(v2,v3)],cube[indexavg(v1,v3)],cube[indexavg(v1,v4)],
-                        cube[indexavg(v2,v4)],cube[indexavg(v3,v4)]))
+            cells[cell_idx + idx] = JFM.QuadraticTetrahedron((cube[v1], cube[v2], cube[v3], cube[v4],
+                        cube[_indexavg(v1,v2)], cube[_indexavg(v2,v3)], cube[_indexavg(v1,v3)],
+                        cube[_indexavg(v1,v4)], cube[_indexavg(v2,v4)], cube[_indexavg(v3,v4)]))
         end
         cell_idx += cells_per_cube
     end

--- a/src/isoperimetry.jl
+++ b/src/isoperimetry.jl
@@ -12,7 +12,7 @@ function getLength(curve, tensorfield)
         curpoint = curve[j]
         nextpoint = curve[j+1]
         approxTangentVector = nextpoint - curpoint
-        result += sqrt(approxTangentVector ⋅ (tensorfield(curpoint[1],curpoint[2]) * approxTangentVector))
+        result += sqrt(approxTangentVector ⋅ (tensorfield(curpoint[1], curpoint[2]) * approxTangentVector))
     end
     return result
 end
@@ -39,26 +39,21 @@ function getEuclideanArea(curve)
     return result
 end
 
-function get_best_levelset(ctx, u,
-    ncontours,nx,ny,tensorfield,scaling=2.0;
-    bdata=bdata
-    )
+function get_best_levelset(ctx, u, ncontours, nx, ny, tensorfield, scaling=2.0; bdata=bdata)
+    xs = range(ctx.spatialBounds[1][1], stop=ctx.spatialBounds[2][1], length=nx)
+    ys = range(ctx.spatialBounds[1][2], stop=ctx.spatialBounds[2][2], length=ny)
 
-    xs = range(ctx.spatialBounds[1][1],stop=ctx.spatialBounds[2][1],length=nx)
-    ys = range(ctx.spatialBounds[1][2],stop=ctx.spatialBounds[2][2],length=ny)
-
-    u_dofvals = undoBCS(ctx,u,bdata)
+    u_dofvals = undoBCS(ctx, u, bdata)
     u_nodevals = u_dofvals[ctx.node_to_dof]
 
     fs = [evaluate_function_from_node_or_cellvals(ctx, u_nodevals, Vec{2}((x,y)))
-        for x in xs, y in ys
-            ]
-    cl = contours(xs,ys,fs,ncontours)
+        for x in xs, y in ys]
+    cl = contours(xs, ys, fs, ncontours)
 
     currentmin = Inf
     result = nothing
 
-    for cl in lines(contours(xs,ys,fs))
+    for cl in lines(contours(xs, ys, fs))
         area = getEuclideanArea(cl)
         len = getLength(cl, tensorfield)
         isoperim = len^scaling / area

--- a/src/ulam.jl
+++ b/src/ulam.jl
@@ -2,7 +2,7 @@
 #ulam.jl
 #Implements Ulam's method within CoherentStructures.jl
 
-function ulam(ctx::gridContext{2}, f, nx, ny)
+function ulam(ctx::GridContext{2}, f, nx, ny)
     n = ctx.n
     npoints = nx * ny
     area = prod(ctx.spatialBounds[2][:] - ctx.spatialBounds[1][:])

--- a/src/util.jl
+++ b/src/util.jl
@@ -166,7 +166,7 @@ end
 Interprets `u` as an array of coefficients ordered in dof order,
 and reorders them to be in node order.
 """
-function dof2node(ctx::abstractGridContext{dim}, u::Vector) where {dim}
+function dof2node(ctx::AbstractGridContext{dim}, u::Vector) where {dim}
    # n = ctx.n
    # res = fill(0.0, JuAFEM.getnnodes(ctx.grid))
    # for node in 1:n
@@ -229,7 +229,7 @@ end
 
 Return the mesh width of a regular grid.
 """
-function getH(ctx::abstractGridContext)
+function getH(ctx::AbstractGridContext)
     supportedRegularGridTypes = ["regular triangular grid",
                     "regular P2 triangular grid",
                     "regular Delaunay grid",

--- a/test/FEMTransfer.jl
+++ b/test/FEMTransfer.jl
@@ -6,7 +6,7 @@ include("numericalExperiments.jl")
 
 mutable struct FEMTransferExperimentResult
     ctx::CoherentStructures.GridContext
-    bdata::CoherentStructures.BoundaryData
+    bdata::BoundaryData
     ϵ::Float64
     n_stencil_points::Int
     λ::Vector{Complex128}

--- a/test/FEMTransfer.jl
+++ b/test/FEMTransfer.jl
@@ -5,8 +5,8 @@ using CoherentStructures
 include("numericalExperiments.jl")
 
 mutable struct FEMTransferExperimentResult
-    ctx::CoherentStructures.gridContext
-    bdata::CoherentStructures.boundaryData
+    ctx::CoherentStructures.GridContext
+    bdata::CoherentStructures.BoundaryData
     ϵ::Float64
     n_stencil_points::Int
     λ::Vector{Complex128}
@@ -50,7 +50,7 @@ for resolution in gridResolutions
             ctx = regularP2TriangularGrid(resolution, [0.0,0.0],[1.,1.],quadrature_order=5)
         end
         pred  = (x,y) -> peuclidean(x, y, [1, 1]) < 1e-9
-        bdata = boundaryData(ctx,pred) #Periodic boundary
+        bdata = BoundaryData(ctx,pred) #Periodic boundary
         ALPHApreBC = L2GalerkinTOFromInverse(ctx,sminv,ϵ,periodic_directions=(true,true) ,n_stencil_points=n_stencil_points )
         gc()
         ALPHA = applyBCS(ctx,ALPHApreBC,bdata)

--- a/test/convergencePlots.jl
+++ b/test/convergencePlots.jl
@@ -1,12 +1,12 @@
 #(c) 2018 Nathanael Schilling
 
-using CoherentStructures
+using CoherentStructures, Distances
 include("numericalExperiments.jl")
 
 
 LL = Vec{2}([0.0,0.0])
 UR=Vec{2}([2π,2π])
-bdata_predicate = (x,y) -> (CoherentStructures.distmod(x[1],y[1],2π) < 1e-9 && CoherentStructures.distmod(x[2],y[2],2π)<1e-9)
+bdata_predicate = (x, y) -> peuclidean(x, y, [2π, 2π]) < 1e-9
 tC = makeStandardMapTestCase()
 
 
@@ -14,7 +14,7 @@ tC = makeStandardMapTestCase()
 tC = makeDoubleGyreTestCase(0.25)
 
 tC = makeCylinderFlowTestCase()
-ctx = regularTriangularGrid((10,10),tC.LL,tC.UR,quadrature_order=2)
+ctx = regularTriangularGrid((10, 10), tC.LL, tC.UR, quadrature_order=2)
 eR = experimentResult(tC, ctx, :naTO)
 runExperiment!(eR)
 plotExperiment(eR)
@@ -46,12 +46,10 @@ eR = experimentResult(tC, ctx, :naTO)
 runExperiment!(eR)
 plotExperiment(eR)
 
-plot_u(ctx,ones(ctx.n),400,400,color=:rainbow,colorbar=true,clim=(1-1e-16,1))
+plot_u(ctx, ones(ctx.n), 400, 400, color=:rainbow, colorbar=true, clim=(1-1e-16,1))
 Plots.savefig("/tmp/output.svg")
-inv_flow_map = CoherentStructures.standardMapInv
-plot_u_eulerian(ctx, -1*eR.V[:,3],inv_flow_map,
-   LL,UR,300,300,
-   bdata=eR.bdata,color=:rainbow)
+inv_flow_map = standardMapInv
+plot_u_eulerian(ctx, -1*eR.V[:,3], inv_flow_map, LL, UR, 300, 300, bdata=eR.bdata, color=:rainbow)
 
 
 
@@ -62,7 +60,7 @@ tC = makeStandardMapTestCase()
 referenceCtx = regularP2TriangularGrid((200,200),tC.LL,tC.UR)
 reference = experimentResult(tC,referenceCtx, :CG)
 runExperiment!(reference)
-inv_flow_map = CoherentStructures.standardMapInv
+inv_flow_map = standardMapInv
 
 
 results[1].ctx.numberOfPointsInEachDirection

--- a/test/convergencePlotsDone.jl
+++ b/test/convergencePlotsDone.jl
@@ -1004,13 +1004,13 @@ begin
   for j in  [1,2]
     LL = [0.0,-3.0]; UR=[6.371π,3.0]
     if j == 1
-      ctx = regularTriangularGrid((60,20),LL,UR,quadrature_order=2)
+      ctx = regularTriangularGrid((60,20), LL, UR, quadrature_order=2)
     else
-      ctx = regularP2TriangularGrid((30,10),LL,UR,quadrature_order=2)
+      ctx = regularP2TriangularGrid((30,10), LL, UR, quadrature_order=2)
     end
 
-    predicate = (p1,p2) -> abs(p1[2] - p2[2]) < 1e-10 && peuclidean(p1[1], p2[1], UR[1]) < 1e-10
-    bdata = CoherentStructures.BoundaryData(ctx,predicate,[]);
+    predicate = (p1, p2) -> peuclidean(p1, p2, [6.371π, Inf]) < 1e-10
+    bdata = BoundaryData(ctx, predicate, []);
 
     tf = 40*3600*24.0
     t0 = 0.0
@@ -1059,8 +1059,8 @@ for j in (1, 2)
   else
     ctx = regularP2TriangularGrid((10,8),LL,UR,quadrature_order=2)
   end
-  predicate = (p1,p2) -> abs(p1[2] - p2[2]) < 1e-10 && peuclidean(p1[1], p2[1], 6.371π) < 1e-10
-  bdata = CoherentStructures.BoundaryData(ctx,predicate,[]);
+  predicate = (p1, p2) -> peuclidean(p1, p2, [6.371π, Inf]) < 1e-10
+  bdata = BoundaryData(ctx, predicate, []);
 
   cgfun = (x -> mean(pullback_diffusion_tensor(bickleyJet, x,linspace(0.0,40*3600*24,81),
        1.e-8,tolerance=1.e-5)))

--- a/test/convergencePlotsDone.jl
+++ b/test/convergencePlotsDone.jl
@@ -1010,7 +1010,7 @@ begin
     end
 
     predicate = (p1,p2) -> abs(p1[2] - p2[2]) < 1e-10 && peuclidean(p1[1], p2[1], UR[1]) < 1e-10
-    bdata = CoherentStructures.boundaryData(ctx,predicate,[]);
+    bdata = CoherentStructures.BoundaryData(ctx,predicate,[]);
 
     tf = 40*3600*24.0
     t0 = 0.0
@@ -1060,7 +1060,7 @@ for j in (1, 2)
     ctx = regularP2TriangularGrid((10,8),LL,UR,quadrature_order=2)
   end
   predicate = (p1,p2) -> abs(p1[2] - p2[2]) < 1e-10 && peuclidean(p1[1], p2[1], 6.371π) < 1e-10
-  bdata = CoherentStructures.boundaryData(ctx,predicate,[]);
+  bdata = CoherentStructures.BoundaryData(ctx,predicate,[]);
 
   cgfun = (x -> mean(pullback_diffusion_tensor(bickleyJet, x,linspace(0.0,40*3600*24,81),
        1.e-8,tolerance=1.e-5)))

--- a/test/fem_tests.jl
+++ b/test/fem_tests.jl
@@ -3,16 +3,40 @@
 using CoherentStructures, Test
 using Arpack
 
+@testset "1d grids Neumann BC" begin
+    λᵢ = (π^2*(0:5).^2)
+    # TODO: include (regular1dPCGrid, 1e-1),
+    for grid in (regular1dP1Grid, regular1dP2Grid)
+        ctx, _ = @inferred regular1dP1Grid(200)
+        M = @inferred assembleMassMatrix(ctx)
+        K = @inferred assembleStiffnessMatrix(ctx)
+        λ, v = eigs(-K, M, which=:SM, nev=6)
+        @test λ[1] ≈ 0 atol=√eps()
+        @test λ[2:end] ≈ λᵢ[2:end] rtol=1e-3
+    end
+end
+
+@testset "1d grids Dirichlet BC" begin
+    λᵢ = (π^2*(1:6).^2)
+    # TODO: include (regular1dPCGrid, 1e-1),
+    for (grid, tol) in ((regular1dP1Grid, 1e-3), (regular1dP2Grid, 1e-7))
+        ctx, _ = @inferred grid(200)
+        M = @inferred assembleMassMatrix(ctx; bdata=getHomDBCS(ctx))
+        K = @inferred assembleStiffnessMatrix(ctx; bdata=getHomDBCS(ctx))
+        λ, v = eigs(-K, M, which=:SM, nev=6)
+        @test λ ≈ λᵢ rtol=1e-3
+    end
+end
 
 #Tests for adaptive TO method on periodic grid
 @testset "adaptive TO FEM methods" begin
     npoints = 100 * 100
-    LL = [0.0, 0.0]
-    UR = [2π, 2π]
+    LL = (0.0, 0.0)
+    UR = (2π, 2π)
 
     ctx, bdata = randomDelaunayGrid(npoints; on_torus=true, LL=LL, UR=UR)
     #ctx, _ = regularP2TriangularGrid((50,50),LL,UR)
-    #bdata = boundaryData(ctx, PeriodicEuclidean([2π,2π]))
+    #bdata = BoundaryData(ctx, PeriodicEuclidean([2π,2π]))
 
     M = assembleMassMatrix(ctx, bdata=bdata)
     S = assembleStiffnessMatrix(ctx, bdata=bdata)
@@ -24,7 +48,7 @@ using Arpack
 
     λ, v = eigs(D, M, which=:SM, nev=12)
 
-    #Some tests so see nothing changed
+    #Some tests to see nothing changed
     @test abs(λ[2] - (-1.3)) < 1e-1
     @test abs(λ[2] - λ[3]) < 1e-1
 end

--- a/test/fem_tests.jl
+++ b/test/fem_tests.jl
@@ -34,14 +34,14 @@ end
     LL = (0.0, 0.0)
     UR = (2π, 2π)
 
-    ctx, bdata = randomDelaunayGrid(npoints; on_torus=true, LL=LL, UR=UR)
+    ctx, bdata = randomDelaunayGrid(npoints, LL, UR; on_torus=true)
     #ctx, _ = regularP2TriangularGrid((50,50),LL,UR)
     #bdata = BoundaryData(ctx, PeriodicEuclidean([2π,2π]))
 
     M = assembleMassMatrix(ctx, bdata=bdata)
     S = assembleStiffnessMatrix(ctx, bdata=bdata)
     T = adaptiveTOCollocationStiffnessMatrix(
-            ctx, CoherentStructures.standardMap;
+            ctx, standardMap;
             on_torus=true, bdata=bdata,
             volume_preserving=false)
     D = 0.5 * (S + T)

--- a/test/numericalExperiments.jl
+++ b/test/numericalExperiments.jl
@@ -8,7 +8,7 @@ include("testCase.jl")
 mutable struct experimentResult
     experiment::testCase
     ctx::CoherentStructures.GridContext
-    bdata::CoherentStructures.BoundaryData
+    bdata::BoundaryData
     mode::Symbol #One of :naTO, :aTO, :CG, :L2GTOf : L2GTOb, etc..
     done::Bool
     runtime::Float64

--- a/test/numericalExperiments.jl
+++ b/test/numericalExperiments.jl
@@ -7,8 +7,8 @@ include("testCase.jl")
 
 mutable struct experimentResult
     experiment::testCase
-    ctx::CoherentStructures.gridContext
-    bdata::CoherentStructures.boundaryData
+    ctx::CoherentStructures.GridContext
+    bdata::CoherentStructures.BoundaryData
     mode::Symbol #One of :naTO, :aTO, :CG, :L2GTOf : L2GTOb, etc..
     done::Bool
     runtime::Float64
@@ -20,21 +20,21 @@ mutable struct experimentResult
     δ::Float64
 
     #Like below, but make boundary data first
-    function experimentResult(experiment::testCase,ctx::CoherentStructures.gridContext,mode;tolerance=CoherentStructures.default_tolerance,δ=1e-8,solver=CoherentStructures.default_solver)
-        bdata = boundaryData(ctx,experiment.bdata_predicate, experiment.dbc_facesets)
+    function experimentResult(experiment::testCase,ctx::CoherentStructures.GridContext,mode;tolerance=CoherentStructures.default_tolerance,δ=1e-8,solver=CoherentStructures.default_solver)
+        bdata = BoundaryData(ctx,experiment.bdata_predicate, experiment.dbc_facesets)
         result = new(experiment,ctx,bdata,mode,false,-1.0,Vector{Float64}([]),zeros(0,2),Dict{String,Any}(),solver,tolerance,δ)
         return result
     end
 
-    #Constructor from general CoherentStructures.gridContext object
-    function experimentResult(experiment::testCase,ctx::CoherentStructures.gridContext,bdata::CoherentStructures.boundaryData,mode;tolerance=CoherentStructures.default_tolerance,δ=1e-8,solver=CoherentStructures.default_solver)
+    #Constructor from general CoherentStructures.GridContext object
+    function experimentResult(experiment::testCase,ctx::CoherentStructures.GridContext,bdata::CoherentStructures.BoundaryData,mode;tolerance=CoherentStructures.default_tolerance,δ=1e-8,solver=CoherentStructures.default_solver)
         result = new(experiment,ctx,bdata,mode,false,-1.0,Vector{Float64}([]),zeros(0,2),Dict{String,Any}(),solver,tolerance,δ)
         return result
     end
     #For regular Grids:
     function experimentResult(experiment::testCase, gridType::String, howmany , mode;tolerance=CoherentStructure.default_tolerance,δ=1e-8,solver=CoherentStructures.default_solver)
         ctx = regularGrid(gridType,howmany, experiment.LL, experiment.UR)
-        bdata = boundaryData(ctx,experiment.bdata_predicate,experiment.dbc_facesets)
+        bdata = BoundaryData(ctx,experiment.bdata_predicate,experiment.dbc_facesets)
         return experimentResult(experiment,ctx,bdata,mode;tolerance=tolerance, solver=solver,δ=δ)
     end
 
@@ -154,7 +154,7 @@ end
 
 #TODO: Think of moving helper functions like these to GridFunctions.jl
 
-function getnorm(u::Vector{T},ctx::CoherentStructures.gridContext,which="L∞", M=nothing) where {T}
+function getnorm(u::Vector{T},ctx::CoherentStructures.GridContext,which="L∞", M=nothing) where {T}
     if which == "L∞"
         return maximum(abs.(u))
     elseif which == "L2"
@@ -164,8 +164,8 @@ function getnorm(u::Vector{T},ctx::CoherentStructures.gridContext,which="L∞", 
     end
 end
 
-function getInnerProduct(ctx::CoherentStructures.gridContext, u1::Vector{Float64},u2::Vector{Float64},Min=nothing)
-        if Min == nothing
+function getInnerProduct(ctx::CoherentStructures.GridContext, u1::Vector{Float64},u2::Vector{Float64},Min=nothing)
+        if Min === nothing
             M = assembleMassMatrix(ctx)
         else
             M = Min
@@ -174,8 +174,8 @@ function getInnerProduct(ctx::CoherentStructures.gridContext, u1::Vector{Float64
         return  u2 ⋅ Mu1
 end
 
-function getInnerProduct(ctx::CoherentStructures.gridContext, u1::Vector{ComplexF64},u2::Vector{ComplexF64},Min=nothing)
-        if Min == nothing
+function getInnerProduct(ctx::CoherentStructures.GridContext, u1::Vector{ComplexF64},u2::Vector{ComplexF64},Min=nothing)
+        if Min === nothing
             M = assembleMassMatrix(ctx)
         else
             M = Min
@@ -184,7 +184,7 @@ function getInnerProduct(ctx::CoherentStructures.gridContext, u1::Vector{Complex
         return  conj(u2) ⋅ Mu1
 end
 
-function getDiscreteInnerProduct(ctx1::CoherentStructures.gridContext, u1::Vector{Float64}, ctx2::CoherentStructures.gridContext, u2::Vector{Float64},nx=400,ny=400)
+function getDiscreteInnerProduct(ctx1::CoherentStructures.GridContext, u1::Vector{Float64}, ctx2::CoherentStructures.GridContext, u2::Vector{Float64},nx=400,ny=400)
     res = 0.0
     for x in range(ctx1.spatialBounds[1][1],stop=ctx1.spatialBounds[2][1],length=nx)
         for y in range(ctx1.spatialBounds[1][2],stop=ctx1.spatialBounds[2][2],length=ny)


### PR DESCRIPTION
This PR starts a major code overhaul of the FEM parts (grids, point locators, boundary conditions). Changes visible for the user are:

- `boundaryData(args)` -> `BoundaryData(args)`
- corner points of domains like `LL` and `UR` should be given as tuples, not as vectors, for example `LL = (0.0, 0.0)` and `UR = (1.0, 1.0)` (instead of square brackets)