### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/docs/src/Laplace.md
+++ b/docs/src/Laplace.md
@@ -7,14 +7,14 @@ CurrentModule = CoherentStructures
 The LCS approaches implemented and described in this section are strongly influenced
 by ideas developed in the spectral clustering/diffusion maps communities. The
 general references include:
-   * [Shi & Malik, Normalized cuts and image segmentation, 2000](https://dx.doi.org/10.1109/34.868688)
-   * [Coifman & Lafon, Diffusion maps, 2006](https://dx.doi.org/10.1016/j.acha.2006.04.006)
-   * [Marshall & Hirn, Time coupled diffusion maps, 2018](https://dx.doi.org/10.1016/j.acha.2017.11.003)
+   * [Shi & Malik, Normalized cuts and image segmentation, 2000](https://doi.org/10.1109/34.868688)
+   * [Coifman & Lafon, Diffusion maps, 2006](https://doi.org/10.1016/j.acha.2006.04.006)
+   * [Marshall & Hirn, Time coupled diffusion maps, 2018](https://doi.org/10.1016/j.acha.2017.11.003)
 In the LCS context, these ideas have been adopted in the following works:
-   * somewhat related [Froyland & Padberg-Gehle, 2015](https://dx.doi.org/10.1063/1.4926372)
-   * [Hadjighasem et al., 2016](http://dx.doi.org/10.1103/PhysRevE.93.063107)
-   * [Banisch & Koltai, 2017](https://dx.doi.org/10.1063/1.4971788)
-   * [Rypina et al., 2017](https://dx.doi.org/10.5194/npg-24-189-2017)/[Padberg-Gehle & Schneide, 2018](https://dx.doi.org/10.5194/npg-24-661-2017)
+   * somewhat related [Froyland & Padberg-Gehle, 2015](https://doi.org/10.1063/1.4926372)
+   * [Hadjighasem et al., 2016](https://doi.org/10.1103/PhysRevE.93.063107)
+   * [Banisch & Koltai, 2017](https://doi.org/10.1063/1.4971788)
+   * [Rypina et al., 2017](https://doi.org/10.5194/npg-24-189-2017)/[Padberg-Gehle & Schneide, 2018](https://doi.org/10.5194/npg-24-661-2017)
 
 For demonstrations on example cases, please consult the page on
 [Working with trajectories](@ref).

--- a/docs/src/elliptic.md
+++ b/docs/src/elliptic.md
@@ -7,15 +7,15 @@ CurrentModule = CoherentStructures
 ## Background
 
 The following functions implement an LCS methodology developed in the following papers:
-   * [Haller & Beron-Vera, 2012](https://dx.doi.org/10.1016/j.physd.2012.06.012)
-   * [Haller & Beron-Vera, 2013](https://dx.doi.org/10.1017/jfm.2013.391)
-   * [Karrasch, Huhn, and Haller, 2015](https://dx.doi.org/10.1098/rspa.2014.0639)
-Our implementation here follows conceptually [Karrasch, Huhn, and Haller, 2015](https://dx.doi.org/10.1098/rspa.2014.0639),
+   * [Haller & Beron-Vera, 2012](https://doi.org/10.1016/j.physd.2012.06.012)
+   * [Haller & Beron-Vera, 2013](https://doi.org/10.1017/jfm.2013.391)
+   * [Karrasch, Huhn, and Haller, 2015](https://doi.org/10.1098/rspa.2014.0639)
+Our implementation here follows conceptually [Karrasch, Huhn, and Haller, 2015](https://doi.org/10.1098/rspa.2014.0639),
 and is described in detail in the preprint TBD.
 Depending on the indefinite metric tensor field used, the functions below yield
 the following types of coherent structures:
    * black-hole/Lagrangian coherent vortices ([Haller & Beron-Vera, 2012](https://doi.org/10.1017/jfm.2013.391))
-   * elliptic objective Eulerian coherent structures (OECSs) ([Serra & Haller, 2016](https://dx.doi.org/10.1063/1.4951720))
+   * elliptic objective Eulerian coherent structures (OECSs) ([Serra & Haller, 2016](https://doi.org/10.1063/1.4951720))
    * material diffusive transport barriers ([Haller, Karrasch, and Kogelbauer, 2018](https://doi.org/10.1073/pnas.1720177115))
 The general procedure is the following. Assume $T$ is the symmetric tensor field
 of interest, say, (i) the Cauchy-Green strain tensor field $C$, (ii) the
@@ -30,7 +30,7 @@ $\eta_{\lambda}^{\pm} := \sqrt{\frac{\lambda_2 - \lambda}{\lambda_2-\lambda_1}}\
 Tensor singularities are defined as points at which $\lambda_2=\lambda_1$, i.e.,
 at which the two characteristic directions $\xi_1$ and $\xi_2$ are not
 well-defined. As described and exploited in
-[Karrasch et al., 2015](https://dx.doi.org/10.1098/rspa.2014.0639),
+[Karrasch et al., 2015](https://doi.org/10.1098/rspa.2014.0639),
 non-negligible tensor singularities express themselves by an angle gap when
 tracking (the angle of) tensor eigenvector fields along closed paths surrounding
 the singularity. Our approach here avoids computing singularities directly, but

--- a/examples/bickley.jl
+++ b/examples/bickley.jl
@@ -11,7 +11,7 @@
 #md #
 # The Bickley jet flow is a kinematic idealized model of a meandering zonal jet
 # flanked above and below by counterrotating vortices. It was introduced by
-# [Rypina et al.](https://dx.doi.org/10.1175/JAS4036.1); cf. also [del‐Castillo‐Negrete and Morrison](https://doi.org/10.1063/1.858639).
+# [Rypina et al.](https://doi.org/10.1175/JAS4036.1); cf. also [del‐Castillo‐Negrete and Morrison](https://doi.org/10.1063/1.858639).
 #
 # The Bickley jet is described by a time-dependent velocity field arising from a
 # stream-function. The corresponding velocity field is provided by the package and

--- a/examples/rot_double_gyre.jl
+++ b/examples/rot_double_gyre.jl
@@ -12,7 +12,7 @@
 # ## Description
 #
 # The rotating double gyre model was introduced by
-# [Mosovsky & Meiss](https://dx.doi.org/10.1137/100794110). It can be derived from
+# [Mosovsky & Meiss](https://doi.org/10.1137/100794110). It can be derived from
 # the stream function
 #
 # ```math


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!