### PR TITLE
More elliptic vortex funtionality, pullback tensors from tensor fields

### DIFF
--- a/docs/examples/bickley.jl
+++ b/docs/examples/bickley.jl
@@ -57,7 +57,7 @@ yspan = range(ymin, stop=ymax, length=ny)
 P = tuple.(xspan, yspan')
 const δ = 1.e-6
 const D = SymmetricTensor{2,2}([2., 0., 1/2])
-mCG_tensor = u -> av_weighted_CG_tensor(bickley, u, tspan, δ; D=D, tolerance=1e-6, solver=Tsit5())
+mCG_tensor = u -> av_weighted_CG_tensor(bickley, u, tspan, δ; D=(_ -> D), tolerance=1e-6, solver=Tsit5())
 
 C̅ = pmap(mCG_tensor, P; batch_size=ceil(Int, length(P)/nprocs()^2))
 p = LCSParameters(2.0)

--- a/docs/examples/ocean_flow.jl
+++ b/docs/examples/ocean_flow.jl
@@ -62,6 +62,10 @@ C̅ = pmap(mCG_tensor, P; batch_size=ceil(Int, length(P)/nprocs()^2))
 p = LCSParameters(2.5)
 vortices, singularities = ellipticLCS(C̅, xspan, yspan, p)
 
+# Let us compute the area of each vortex has and whether it rotates in a clockwise fashion.
+
+area.(vortices), clockwise.(vortices, interp_rhs, t_initial, p=uv)
+
 # Finally, the result is visualized as follows.
 
 using Plots

--- a/docs/examples/rot_double_gyre.jl
+++ b/docs/examples/rot_double_gyre.jl
@@ -86,7 +86,7 @@ v_upsampled = sample_to(v, ctx, ctx2)
 numclusters=2
 res = kmeans(permutedims(v_upsampled[:,2:numclusters+1]), numclusters + 1)
 u = kmeansresult2LCS(res)
-res = Plots.plot([plot_u(ctx2, u[:,i], 200, 200, color=:viridis, colorbar=:none) for i in 1:3]...)
+res = Plots.plot([plot_u(ctx2, u[:,i], 200, 200, c=:viridis, cbar=:none) for i in 1:3]...)
 
 DISPLAY_PLOT(res, rot_double_gyre_fem)
 

--- a/docs/src/elliptic.md
+++ b/docs/src/elliptic.md
@@ -154,4 +154,7 @@ to compute the area of [`EllipticBarrier`](@ref) and [`EllipticVortex`](@ref) ob
 FlowGrowParams
 flowgrow
 area
+center
+clockwise
+Base.extrema
 ```

--- a/src/ellipticLCS.jl
+++ b/src/ellipticLCS.jl
@@ -1587,12 +1587,12 @@ function in_uniform_squares(xs, λ⁰, cache)
 end
 
 function contains_point(xs, point_to_check)
-    points_to_center = [x - point_to_check for x in xs]
+    points_to_center = (x - point_to_check for x in xs)
     angles = [atan(x[2], x[1]) for x in points_to_center]
     lx = length(xs)
     res = 0.0
     for i in 0:(lx-1)
-        res += s1dist(angles[i+1], angles[((i+1)%lx)+1])
+        res += S1Dist()(angles[i + 1], angles[((i + 1)%lx) + 1])
     end
     res /= 2π
     return !iszero(round(res))

--- a/src/ellipticLCS.jl
+++ b/src/ellipticLCS.jl
@@ -15,7 +15,7 @@ struct Singularity{T<:Real}
     index::Rational{Int}
 end
 function Singularity(coords::SVector{2}, index::Real)
-    return Singularity(coords, convert(Rational, index))
+    return Singularity(coords, convert(Rational{Int}, index))
 end
 function Singularity(coords::NTuple{2,Real}, index::Real)
     return Singularity(SVector{2}(coords), index)
@@ -1804,3 +1804,74 @@ function area(poly::Vector{SVector{2,T}}) where {T}
 end
 area(barrier::EllipticBarrier) = area(barrier.curve)
 area(vortex::EllipticVortex)   = area(last(vortex.barriers))
+
+"""
+    center(polygon)
+
+Compute the center (of mass) of `polygon`, which can be of type `Vector{SVector{2}}`,
+`EllipticBarrier` or `EllipticVortex`. In the latter case, the center of
+the outermost (i.e., the last `EllipticBarrier` in the `barriers` field) is computed.
+"""
+function center(poly::Vector{SVector{2,T}}) where {T}
+    result = float(zero(eltype(poly)))
+    a = zero(T)
+    @inbounds @simd for i in 1:length(poly) - 1
+        p1 = poly[i]
+        p2 = poly[i+1]
+        pd = p1[1]*p2[2]-p2[1]*p1[2]
+        result += (p1 + p2) * pd
+        a += pd
+    end
+    p1 = last(poly)
+    p2 = first(poly)
+    a += p1[1]*p2[2]-p2[1]*p1[2] # yields the double of the area
+    result /= (3a) # should be divided by 6*area
+    return result
+end
+center(barrier::EllipticBarrier) = center(barrier.curve)
+center(vortex::EllipticVortex)   = center(last(vortex.barriers))
+
+"""
+    Base.extrema(barrier) -> (LL, UR)
+    Base.extrema(vortex) -> (LL, UR)
+
+Compute an axis-aligned, rectangular bounding box around an [`EllipticVortex`](@ref)
+or an [`EllipticBarrier`](@ref). Returns the coordinates of the lower left corner `LL`
+and of the upper right corner `UR`.
+"""
+function Base.extrema(barrier::EllipticBarrier)
+    xmin, xmax = extrema(c[1] for c in barrier.curve)
+    ymin, ymax = extrema(c[2] for c in barrier.curve)
+    return SVector{2}((xmin, ymin)), SVector{2}((xmax, ymax))
+end
+Base.extrema(vortex::EllipticVortex) = extrema(last(vortex.barriers))
+
+"""
+    clockwise(barrier, velocity, t0; p=nothing) -> Bool
+    clockwise(vortex, velocity, t0; p=nothing) -> Bool
+
+Determine whether a given `vortex` or `barrier` is instantaneously (at `t0`) rotating
+clockwise due to the velocity field `velocity`. The keyword argument `p` is a parameter
+passed to `velocity`, for instance the interpolant of the interpolating velocity field
+[`interp_rhs`](@ref).
+
+Clockwise-rotating vortices correspond to anticyclones in the Northern hemisphere and to
+cyclones in the Southern hemisphere.
+"""
+function clockwise(barrier::EllipticBarrier, velo::ODE.ODEFunction{false}, t0; p=nothing)
+    curve = barrier.curve
+    result = 0.0
+    pprev = curve[end-1]
+    pcurr = curve[1]
+    pnext = curve[2]
+    pdiff = pnext - pprev
+    @assert pdiff[2] > 0
+    result = dot(velo(pcurr, p, t0), pdiff)
+    @inbounds for i in 3:length(curve)
+        pprev, pcurr, pnext = pcurr, pnext, curve[i]
+        result += dot(velo(pcurr, p, t0), pnext - pprev)
+    end
+    return result < 0
+end
+clockwise(vortex::EllipticVortex, velo, t0; p=nothing) =
+    clockwise(last(vortex.barriers), velo, t0; p=p)

--- a/src/exports.jl
+++ b/src/exports.jl
@@ -30,6 +30,8 @@ export
 	flowgrow,
 	FlowGrowParams,
 	area,
+	center,
+	clockwise,
 
 	#diffusion_operators.jl
 	gaussian,

--- a/test/test_elliptic.jl
+++ b/test/test_elliptic.jl
@@ -172,10 +172,16 @@ end
     @test area(square) ≈ 4 rtol=5eps()
     @test center(square) ≈ ones(2) atol=5eps()
     barrier = EllipticBarrier(circle, SVector{2}(0.0, 0.0), 1.0, true)
+    vortices = EllipticVortex(SVector{2}(0.0, 0.0), [barrier])
     LL, UR = extrema(barrier)
+    @test area(vortices) == area(barrier) == area(circle)
+    @test center(vortices) == center(barrier) == center(circle)
+    @test extrema(vortices) == extrema(barrier)
     @test LL ≈ -ones(2) rtol=1e-5
     @test UR ≈ ones(2) rtol=1e-6
     @test !clockwise(barrier, ODEFunction((u, p, t) -> SVector{2}(-u[2], u[1])), 0)
+    @test clockwise(barrier, ODEFunction((u, p, t) -> SVector{2}(-u[2], u[1])), 0) ==
+        clockwise(vortices, ODEFunction((u, p, t) -> SVector{2}(-u[2], u[1])), 0)
     barrier = EllipticBarrier(square, SVector{2}(1.0, 1.0), 1.0, true)
     LL, UR = extrema(barrier)
     @test LL ≈ zeros(2)

--- a/test/test_elliptic.jl
+++ b/test/test_elliptic.jl
@@ -165,7 +165,7 @@ end
 @testset "elliptic utils" begin
     circle = SVector.([reverse(sincos(x)) for x in range(0, 2pi, length=1000)])
     @test area(circle) ≈ π rtol=1e-5
-    @test center(circle) ≈ zeros(2) atol=eps()
+    @test center(circle) ≈ zeros(2) atol=5eps()
     dense = range(-1, 1, length=101)
     sparse = range(1, -1, length=11)
     square = SVector{2}.(vcat(vcat.(1, dense), vcat.(sparse, 1), vcat.(-1, sparse), vcat.(dense, -1)) .+ Ref(ones(2)))

--- a/test/test_elliptic.jl
+++ b/test/test_elliptic.jl
@@ -161,3 +161,22 @@ end
         @test singularities[1].coords ≈ Z atol=max(step(xspan), step(yspan))
     end
 end
+
+@testset "elliptic utils" begin
+    circle = SVector.([reverse(sincos(x)) for x in range(0, 2pi, length=1000)])
+    @test area(circle) ≈ π rtol=1e-5
+    @test center(circle) ≈ zeros(2) atol=eps()
+    dense = range(-1, 1, length=101)
+    sparse = range(1, -1, length=11)
+    square = SVector{2}.(vcat(vcat.(dense, -1), vcat.(1, dense), vcat.(sparse, 1), vcat.(-1, sparse))) .+ Ref(ones(2))
+    @test area(square) ≈ 4 rtol=eps()
+    @test center(square) ≈ ones(2) atol=eps()
+    barrier = EllipticBarrier(circle, SVector{2}(0.0, 0.0), 1.0, true)
+    LL, UR = extrema(barrier)
+    @test LL ≈ -ones(2) rtol=1e-5
+    @test UR ≈ ones(2) rtol=1e-6
+    barrier = EllipticBarrier(square, SVector{2}(1.0, 1.0), 1.0, true)
+    LL, UR = extrema(barrier)
+    @test LL ≈ zeros(2)
+    @test UR ≈ 2ones(2)
+end

--- a/test/test_elliptic.jl
+++ b/test/test_elliptic.jl
@@ -168,17 +168,17 @@ end
     @test center(circle) ≈ zeros(2) atol=eps()
     dense = range(-1, 1, length=101)
     sparse = range(1, -1, length=11)
-    square = SVector{2}.(vcat(vcat.(dense, -1), vcat.(1, dense), vcat.(sparse, 1), vcat.(-1, sparse))) .+ Ref(ones(2))
+    square = SVector{2}.(vcat(vcat.(1, dense), vcat.(sparse, 1), vcat.(-1, sparse), vcat.(dense, -1)) .+ Ref(ones(2)))
     @test area(square) ≈ 4 rtol=5eps()
     @test center(square) ≈ ones(2) atol=5eps()
     barrier = EllipticBarrier(circle, SVector{2}(0.0, 0.0), 1.0, true)
     LL, UR = extrema(barrier)
     @test LL ≈ -ones(2) rtol=1e-5
     @test UR ≈ ones(2) rtol=1e-6
-    @test !clockwise(barrier, ODEFunction((u, p, t) -> SVector{2}(u[2], -u[1])), 0)
+    @test !clockwise(barrier, ODEFunction((u, p, t) -> SVector{2}(-u[2], u[1])), 0)
     barrier = EllipticBarrier(square, SVector{2}(1.0, 1.0), 1.0, true)
     LL, UR = extrema(barrier)
     @test LL ≈ zeros(2)
     @test UR ≈ 2ones(2)
-    @test !clockwise(barrier, ODEFunction((u, p, t) -> SVector{2}(u[2], -u[1])), 0)
+    @test !clockwise(barrier, ODEFunction((u, p, t) -> SVector{2}(-u[2], u[1])), 0)
 end

--- a/test/test_elliptic.jl
+++ b/test/test_elliptic.jl
@@ -169,14 +169,16 @@ end
     dense = range(-1, 1, length=101)
     sparse = range(1, -1, length=11)
     square = SVector{2}.(vcat(vcat.(dense, -1), vcat.(1, dense), vcat.(sparse, 1), vcat.(-1, sparse))) .+ Ref(ones(2))
-    @test area(square) ≈ 4 rtol=eps()
-    @test center(square) ≈ ones(2) atol=eps()
+    @test area(square) ≈ 4 rtol=5eps()
+    @test center(square) ≈ ones(2) atol=5eps()
     barrier = EllipticBarrier(circle, SVector{2}(0.0, 0.0), 1.0, true)
     LL, UR = extrema(barrier)
     @test LL ≈ -ones(2) rtol=1e-5
     @test UR ≈ ones(2) rtol=1e-6
+    @test !clockwise(barrier, ODEFunction((u, p, t) -> SVector{2}(u[2], -u[1])), 0)
     barrier = EllipticBarrier(square, SVector{2}(1.0, 1.0), 1.0, true)
     LL, UR = extrema(barrier)
     @test LL ≈ zeros(2)
     @test UR ≈ 2ones(2)
+    @test !clockwise(barrier, ODEFunction((u, p, t) -> SVector{2}(u[2], -u[1])), 0)
 end

--- a/test/test_pullback_tensors.jl
+++ b/test/test_pullback_tensors.jl
@@ -83,8 +83,11 @@ end
         Sspan = fill(S, length(tspan))
         for v in (voop, viip)
             @test det(S)*inv(S) ≈ av_weighted_CG_tensor(v, x0, tspan, 0.1; D=(_ -> S))
-            @test Sspan ≈ pullback_diffusion_tensor(v, x0, tspan, 0.1; D=(_ -> S))
-            @test Sspan ≈ pullback_metric_tensor(v, x0, tspan, 0.1; G=(_ -> S))
+            pbdt = pullback_diffusion_tensor(v, x0, tspan, 0.1; D=(_ -> S))
+            @test Sspan ≈ pbdt
+            pbmt = pullback_metric_tensor(v, x0, tspan, 0.1; G=(_ -> inv(S)))
+            @test inv.(Sspan) ≈ pbmt
+            @test all(pullback_tensors(v, x0, tspan, 0.1; D=(_ -> S)) .≈ (pbmt, pbdt))
             @test fill(B, length(tspan)) ≈ pullback_SDE_diffusion_tensor(v, x0, tspan, 0.1; B=(_ -> B))
         end
         for x in (xs, xt, xv), v in (voop, viip)

--- a/test/test_pullback_tensors.jl
+++ b/test/test_pullback_tensors.jl
@@ -82,16 +82,16 @@ end
         B = rand(Tensor{2,dim})
         Sspan = fill(S, length(tspan))
         for v in (voop, viip)
-            @test det(S)*inv(S) ≈ av_weighted_CG_tensor(v, x0, tspan, 0.1; D=S)
-            @test Sspan ≈ pullback_diffusion_tensor(v, x0, tspan, 0.1; D=S)
-            @test Sspan ≈ pullback_metric_tensor(v, x0, tspan, 0.1; G=S)
-            @test fill(B, length(tspan)) ≈ pullback_SDE_diffusion_tensor(v, x0, tspan, 0.1; B=B)
+            @test det(S)*inv(S) ≈ av_weighted_CG_tensor(v, x0, tspan, 0.1; D=(_ -> S))
+            @test Sspan ≈ pullback_diffusion_tensor(v, x0, tspan, 0.1; D=(_ -> S))
+            @test Sspan ≈ pullback_metric_tensor(v, x0, tspan, 0.1; G=(_ -> S))
+            @test fill(B, length(tspan)) ≈ pullback_SDE_diffusion_tensor(v, x0, tspan, 0.1; B=(_ -> B))
         end
         for x in (xs, xt, xv), v in (voop, viip)
-            @test det(S)*inv(S) ≈ @inferred(av_weighted_CG_tensor(v, x, tspan, 0.1; D=S))
-            @test Sspan ≈ @inferred(pullback_diffusion_tensor(v, x, tspan, 0.1; D=S))
-            @test Sspan ≈ @inferred(pullback_metric_tensor(v, x, tspan, 0.1; G=S))
-            @test fill(B, length(tspan)) ≈ @inferred(pullback_SDE_diffusion_tensor(v, x, tspan, 0.1; B=B))
+            @test det(S)*inv(S) ≈ @inferred(av_weighted_CG_tensor(v, x, tspan, 0.1; D=(_ -> S)))
+            @test Sspan ≈ @inferred(pullback_diffusion_tensor(v, x, tspan, 0.1; D=(_ -> S)))
+            @test Sspan ≈ @inferred(pullback_metric_tensor(v, x, tspan, 0.1; G=(_ -> S)))
+            @test fill(B, length(tspan)) ≈ @inferred(pullback_SDE_diffusion_tensor(v, x, tspan, 0.1; B=(_ -> B)))
         end
     end
     # check linear vector field
@@ -125,7 +125,7 @@ end
         end
     end
 end
- 
+
 @testset "variational equation" begin
     include("define_vector_fields.jl")
     @test (@inferred CG_tensor(var_rot_double_gyre, (0.5, 0.5), [0.0, 5.0], 0.0)) isa SymmetricTensor


### PR DESCRIPTION
This PR adds functionality to compute the area, the center of mass and the rotation direction of vortices. Moreover, it generalizes all pullback tensor functions towards being able to pull back tensor fields.