### PR TITLE
Bugfix for periodic boundary conditions

### DIFF
--- a/src/TO.jl
+++ b/src/TO.jl
@@ -145,13 +145,10 @@ function adaptiveTOCollocationStiffnessMatrix(ctx::GridContext{2}, flow_maps, ti
     else
         N = length(times)
     end
-    num_real_points = ctx.n
-    if on_torus || on_cylinder
-        num_real_points = ctx.n - length(bdata.periodic_dofs_from)
-    end
-    flow_map_images = zeros(Vec{2}, (N,num_real_points))
+
+    flow_map_images = zeros(Vec{2}, (N,ctx.n))
     if times === nothing
-        for i in 1:num_real_points
+        for i in 1:ctx.n
             if flow_map_mode == 0
                 flow_map_images[1,i] = Vec{2}(flow_maps(ctx.grid.nodes[i].x))
             else
@@ -159,7 +156,7 @@ function adaptiveTOCollocationStiffnessMatrix(ctx::GridContext{2}, flow_maps, ti
             end
         end
     else
-        for i in 1:num_real_points
+        for i in 1:ctx.n
             if flow_map_mode == 0
                 flow_map_images[:,i] = Vec{2}.(flow_maps(ctx.grid.nodes[i].x, times))
             else

--- a/test/test_fem.jl
+++ b/test/test_fem.jl
@@ -155,4 +155,15 @@ end
 
     λ, = get_smallest_eigenpairs(D, M, 3)
     @test all(<(sqrt(eps())), λ)
+
+    LL, UR = (0., 0.), (1., 1.)
+    gs = 10
+    ctx, _ = regularTriangularGrid((gs, gs), LL, UR);
+    predicate = (p1, p2) -> peuclidean(p1, p2, [1.0,Inf]) < 2e-10
+    bdata = BoundaryData(ctx, predicate, [])
+
+    @test !isnothing(
+        adaptiveTOCollocationStiffnessMatrix(
+            ctx, identity; on_cylinder=true, bdata)
+       )
 end


### PR DESCRIPTION
Currently, the following code throws an exception:
```julia 
using CoherentStructures
using Distances

LL, UR = (0., 0.), (1., 1.)
gs = 10
ctx, _ = regularTriangularGrid((gs, gs), LL, UR);
predicate = (p1, p2) -> peuclidean(p1, p2, [1.0,Inf]) < 2e-10
bdata = BoundaryData(ctx, predicate, [])

adaptiveTOCollocationStiffnessMatrix(ctx, identity; on_cylinder=true, bdata)
```

It looks like this happens because in `adaptiveTOCollocationStiffnessMatrix` there is an attempt to avoid unnecessary evaluations of the flow by only applying it to the first `num_real_points` points. The actual redundant points however, may be distributed differently across the indices. Also, in `adaptiveTOFutureGrid`, it is assumed that `flow_map_images` is populated with the images of every point, so this is where the error is thrown. 

This seems like the most direct fix. As the redundant points are typically on the boundary and thus very few, the effect on performance should be negligible.